### PR TITLE
Remove React as a peer dependency

### DIFF
--- a/packages/block-editor-tools/package-lock.json
+++ b/packages/block-editor-tools/package-lock.json
@@ -14,7 +14,6 @@
         "lodash": "^4.17.21",
         "papaparse": "^5.3.2",
         "prop-types": "^15.8.1",
-        "react": "^18.2.0",
         "styled-components": "^5.3.5",
         "uuid": "^8.3.2"
       },
@@ -4545,6 +4544,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8773,6 +8773,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/packages/block-editor-tools/package.json
+++ b/packages/block-editor-tools/package.json
@@ -39,7 +39,6 @@
     "lodash": "^4.17.21",
     "papaparse": "^5.3.2",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
     "styled-components": "^5.3.5",
     "uuid": "^8.3.2"
   },

--- a/packages/block-editor-tools/src/components/audio-picker/index.jsx
+++ b/packages/block-editor-tools/src/components/audio-picker/index.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import styled from 'styled-components';
 
 // Components.

--- a/packages/block-editor-tools/src/components/checkboxes/index.jsx
+++ b/packages/block-editor-tools/src/components/checkboxes/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import { BaseControl, CheckboxControl } from '@wordpress/components';

--- a/packages/block-editor-tools/src/components/csv-uploader/index.jsx
+++ b/packages/block-editor-tools/src/components/csv-uploader/index.jsx
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import { parseCSVFile } from '@/services';

--- a/packages/block-editor-tools/src/components/image-picker/index.jsx
+++ b/packages/block-editor-tools/src/components/image-picker/index.jsx
@@ -1,6 +1,5 @@
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
-import React from 'react';
 import styled from 'styled-components';
 
 // Components.

--- a/packages/block-editor-tools/src/components/media-picker/index.jsx
+++ b/packages/block-editor-tools/src/components/media-picker/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 

--- a/packages/block-editor-tools/src/components/post-selector/index.jsx
+++ b/packages/block-editor-tools/src/components/post-selector/index.jsx
@@ -1,5 +1,4 @@
 // Dependencies.
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import { __ } from '@wordpress/i18n';

--- a/packages/block-editor-tools/src/components/safe-html/index.jsx
+++ b/packages/block-editor-tools/src/components/safe-html/index.jsx
@@ -1,6 +1,5 @@
 import DOMPurify from 'dompurify';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const SafeHTML = ({
   className,

--- a/packages/block-editor-tools/src/components/selector/components/search-results.jsx
+++ b/packages/block-editor-tools/src/components/selector/components/search-results.jsx
@@ -1,5 +1,4 @@
 // Dependencies.
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Button } from '@wordpress/components';

--- a/packages/block-editor-tools/src/components/selector/index.jsx
+++ b/packages/block-editor-tools/src/components/selector/index.jsx
@@ -1,5 +1,4 @@
 // Dependencies.
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
   useCallback,

--- a/packages/block-editor-tools/src/components/term-selector/index.jsx
+++ b/packages/block-editor-tools/src/components/term-selector/index.jsx
@@ -1,5 +1,4 @@
 // Dependencies.
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import { __ } from '@wordpress/i18n';

--- a/packages/block-editor-tools/src/components/video-picker/index.jsx
+++ b/packages/block-editor-tools/src/components/video-picker/index.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import styled from 'styled-components';
 
 // Components.


### PR DESCRIPTION
React will be externalized by the dependency extraction wordpress plugin, so there's no need to include it here, and you no longer need React to be in scope for JSX since version 17.

See: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html