### PR TITLE
Bump ESLint package version for publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18211,7 +18211,7 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "@alleyinteractive/eslint-config": "^0.0.1",
+        "@alleyinteractive/eslint-config": "*",
         "@babel/core": "^7.21.3",
         "@babel/preset-env": "^7.18.9",
         "@babel/preset-react": "^7.18.6",
@@ -20683,7 +20683,7 @@
     },
     "packages/eslint-config": {
       "name": "@alleyinteractive/eslint-config",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": ">= 7",
@@ -20772,7 +20772,7 @@
     "@alleyinteractive/block-editor-tools": {
       "version": "file:packages/block-editor-tools",
       "requires": {
-        "@alleyinteractive/eslint-config": "^0.0.1",
+        "@alleyinteractive/eslint-config": "*",
         "@alleyinteractive/tsconfig": "*",
         "@babel/core": "^7.21.3",
         "@babel/preset-env": "^7.18.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alleyinteractive/alley-scripts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alleyinteractive/alley-scripts",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "GPL-2.0-or-later",
       "workspaces": [
         "packages/block-editor-tools",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alleyinteractive/alley-scripts",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alleyinteractive/alley-scripts",
-      "version": "0.1.1",
+      "version": "0.1.0",
       "license": "GPL-2.0-or-later",
       "workspaces": [
         "packages/block-editor-tools",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alleyinteractive/alley-scripts",
   "description": "Shared packages from Alley Interactive.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Alley Interactive",
   "license": "GPL-2.0-or-later",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alleyinteractive/alley-scripts",
   "description": "Shared packages from Alley Interactive.",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "author": "Alley Interactive",
   "license": "GPL-2.0-or-later",
   "engines": {

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.2 - 2023-03-28
+
+- Add support for JSX in `.tsx` files.
+- Fix for including files for multiple configurations.
+
 ## [0.0.1] - 2023-01-10
 
 - Initial version. Basic support for common use cases at Alley.

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -62,5 +62,5 @@
   "scripts": {
     "lint": "eslint ."
   },
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/packages/eslint-config/typescript-react/index.js
+++ b/packages/eslint-config/typescript-react/index.js
@@ -12,6 +12,7 @@ module.exports = {
     ...packageConfigs,
   ],
   rules: {
+    'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.tsx'] }],
     'react/require-default-props': 'off',
   },
 };


### PR DESCRIPTION
To ensure files are published the eslint-config needs to be bumped as a patch version.