### PR TITLE
Reorder ESLint extends for typescript-react config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20683,7 +20683,7 @@
     },
     "packages/eslint-config": {
       "name": "@alleyinteractive/eslint-config",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": ">= 7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20683,7 +20683,7 @@
     },
     "packages/eslint-config": {
       "name": "@alleyinteractive/eslint-config",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": ">= 7",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.3 - 2023-03-29
+
+- Reorder ESLint extends in `/typescript-react` to ensure proper rules are followed.
+
 ## 0.0.2 - 2023-03-28
 
 - Add support for JSX in `.tsx` files.

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.3 - 2023-03-29
+## 0.1.0 - 2023-03-29
 
 - Reorder ESLint extends in `/typescript-react` to ensure proper rules are followed.
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -62,5 +62,5 @@
   "scripts": {
     "lint": "eslint ."
   },
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -62,5 +62,5 @@
   "scripts": {
     "lint": "eslint ."
   },
-  "version": "0.0.3"
+  "version": "0.1.0"
 }

--- a/packages/eslint-config/typescript-react/index.js
+++ b/packages/eslint-config/typescript-react/index.js
@@ -8,8 +8,8 @@ const packageConfigs = [
 
 module.exports = {
   extends: [
-    'airbnb-typescript',
     ...packageConfigs,
+    'airbnb-typescript',
   ],
   rules: {
     'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.tsx'] }],


### PR DESCRIPTION
Reorder ESLint extends in `/typescript-react` to ensure proper rules are followed.
This prevents and error where import/extensions don't support `.ts` files.