### PR TITLE
Spinner when selected image is deleted

### DIFF
--- a/packages/block-editor-tools/src/components/media-picker/index.jsx
+++ b/packages/block-editor-tools/src/components/media-picker/index.jsx
@@ -45,9 +45,9 @@ const MediaPicker = ({
 }) => {
   // Get the media object, if given the media ID.
   const {
-    media = null,
+    media = undefined,
   } = useSelect((select) => ({
-    media: value ? select('core').getMedia(value) : null,
+    media: value ? select('core').getMedia(value) : undefined,
   }), [value]);
 
   // getEntityRecord returns `null` if the load is in progress.


### PR DESCRIPTION
Avoids returning `Spinner` component when a previously selected media is deleted or can not be found. Renders the `MediaPlaceholder` so another media file can be picked.

https://github.com/alleyinteractive/alley-scripts/issues/43