### PR TITLE
Ignore global scope sniff for Render files

### DIFF
--- a/packages/create-block/templates/javascript/render.php.mustache
+++ b/packages/create-block/templates/javascript/render.php.mustache
@@ -5,6 +5,8 @@
  *
  * All of the parameters passed to the function where this file is being required are accessible in this scope:
  *
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- File doesn't load in global scope, just appears to to PHPCS.
+ *
  * @var array    $attributes The array of attributes for this block.
  * @var string   $content    Rendered block output. ie. <InnerBlocks.Content />.
  * @var WP_Block $block      The instance of the WP_Block class that represents the block being rendered.

--- a/packages/create-block/templates/typescript/render.php.mustache
+++ b/packages/create-block/templates/typescript/render.php.mustache
@@ -5,6 +5,8 @@
  *
  * All of the parameters passed to the function where this file is being required are accessible in this scope:
  *
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- File doesn't load in global scope, just appears to to PHPCS.
+ *
  * @var array    $attributes The array of attributes for this block.
  * @var string   $content    Rendered block output. ie. <InnerBlocks.Content />.
  * @var WP_Block $block      The instance of the WP_Block class that represents the block being rendered.


### PR DESCRIPTION
This PR adds PHPCS Disable comments to disabled the `WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound` sniff in the `render.php` template.

This file is loaded outside of global scope, but PHPCS isn't aware of that.