### PR TITLE
AOS-40 - Update help description, fix enqueue param in template

### DIFF
--- a/packages/create-entry/README.md
+++ b/packages/create-entry/README.md
@@ -34,8 +34,7 @@ Without providing any options the tool will prompt the user through several opti
   -h, --help                Prints this usage guide                                           
   -n, --namespace string    Internal namespace for the entry point. (default is "create-      
                             entry")                                                           
-  -s, --slotfill            Text domain for setting translated strings for a script. (default 
-                            is empty or "default")                                            
+  -s, --slotfill            Create a slotfill entry point.
   -t, --textdomain string   Text domain for setting translated strings for a script. (default 
                             is empty or "default")    
 ```
@@ -63,12 +62,11 @@ If the PHP file is included an optional namespace prompt is provided if the user
 * Add project specific flags to the command setting `--src-dir`, `--namespace`, and `--textdomain` accordingly.
 * Add a separate `create-slotfill` script command in the projects `package.json` file with the necessary flags to scaffold a slotfill entry point.
 
-Example: 
+Example in `package.json`: 
 ```json
-// package.json
 "scripts": {
-    "create-entry": "npx @alleyinteractive/create-entry --src-dir=src --namespace=create-wordpress-plugin --textdomain=create-wordpress-plugin",
-    "create-slotfill": "npx @alleyinteractive/create-entry --slotfill --src-dir=src --namespace=create-wordpress-plugin --textdomain=create-wordpress-plugin",
+    "create-entry": "npx @alleyinteractive/create-entry --src-dir src --namespace create-wordpress-plugin --textdomain create-wordpress-plugin",
+    "create-slotfill": "npx @alleyinteractive/create-entry --slotfill --src-dir src --namespace create-wordpress-plugin --textdomain create-wordpress-plugin",
 }
 ```
 

--- a/packages/create-entry/src/entryArgs.ts
+++ b/packages/create-entry/src/entryArgs.ts
@@ -36,7 +36,7 @@ const entryArgs = parse<EntryArgs>(
     slotfill: {
       type: Boolean,
       alias: 's',
-      description: 'Text domain for setting translated strings for a script. (default is empty or "default")',
+      description: 'Create a slotfill entry point.',
       optional: true,
     },
     textdomain: {

--- a/packages/create-entry/templates/slotfill/index.php.mustache
+++ b/packages/create-entry/templates/slotfill/index.php.mustache
@@ -27,7 +27,7 @@ function {{nameSpaceSnakeCase}}_register_{{slugUnderscore}}_scripts() {
 		plugins_url( 'index.js', __FILE__ ),
 		$asset_file['dependencies'],
 		$asset_file['version'],
-		trues
+		true
 	);
 	wp_set_script_translations( '{{prefixNameSpace}}-{{slug}}-js'{{#textdomain}}, '{{textdomain}}'{{/textdomain}} );
 	{{#hasStyles}}


### PR DESCRIPTION
This PR addresses the following in the `create-entry` package:
* Fixes a typo for a `wp_enqueue_script` parameter in a mustache template.
* Updates the slotfill description.