### PR TITLE
Button: update misleading name

### DIFF
--- a/packages/block-editor-tools/src/components/media-picker/index.jsx
+++ b/packages/block-editor-tools/src/components/media-picker/index.jsx
@@ -68,7 +68,7 @@ const MediaPicker = ({
           isPrimary
           onClick={onReset}
         >
-          {__('Replace', 'alley-scripts')}
+          {__('Reset', 'alley-scripts')}
         </Button>
       );
     }


### PR DESCRIPTION
The name of this button is misleading since it doesn't open the dialog box so that an editor could replace the image but in fact, resets the image whereas the editor can either choose to add/choose a new one or not.

As a ESL speaker: Reset instead of Replace seems like a more appropriate name.