### PR TITLE
PostPicker - Display flex items to fit container

### DIFF
--- a/packages/block-editor-tools/package.json
+++ b/packages/block-editor-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alleyinteractive/block-editor-tools",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A set of tools to help build products for the WordPress block editor.",
   "main": "./build/index.bundle.min.js",
   "types": "./build/index.d.ts",

--- a/packages/block-editor-tools/src/components/post-picker/post-list.scss
+++ b/packages/block-editor-tools/src/components/post-picker/post-list.scss
@@ -6,6 +6,7 @@
   justify-content: flex-start;
   overflow-y: auto;
   padding: 8px;
+  width: 100%;
 }
 
 .alley-scripts-post-picker__post {


### PR DESCRIPTION
When around less than 5 posts appear in the post picker modal, the items appear squished:
![image](https://github.com/alleyinteractive/alley-scripts/assets/370019/80cf19c9-09e8-404a-99d1-416dbed7e297)

This change adds a width to the post picker list flex container so the items fit the container:
![image](https://github.com/alleyinteractive/alley-scripts/assets/370019/06aa122c-da6d-4899-8532-59fbdc5cf03d)

