### PR TITLE
Add new `useBlocks` hooks and fixes the `useParentBlock` hook

### DIFF
--- a/packages/block-editor-tools/src/hooks/use-block-name/README.md
+++ b/packages/block-editor-tools/src/hooks/use-block-name/README.md
@@ -1,0 +1,22 @@
+# Custom Hooks: useParentBlock
+
+A custom React hook that returns the name of a block.
+
+## Usage
+
+```jsx
+const MyBlock = ({ clientId }) => {
+  const blockName = useBlockName(clientId);
+
+  ...
+};
+```
+
+```jsx
+const MyBlock = ({ clientId }) => {
+  const parentBlockClientId = useParentClientId(clientId);
+  const parentBlockName = useBlockName(parentBlockClientId);
+
+  ...
+};
+```

--- a/packages/block-editor-tools/src/hooks/use-block-name/README.md
+++ b/packages/block-editor-tools/src/hooks/use-block-name/README.md
@@ -1,4 +1,4 @@
-# Custom Hooks: useParentBlock
+# Custom Hooks: useBlockName
 
 A custom React hook that returns the name of a block.
 

--- a/packages/block-editor-tools/src/hooks/use-block-name/index.js
+++ b/packages/block-editor-tools/src/hooks/use-block-name/index.js
@@ -1,0 +1,15 @@
+import { store } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Get the name of a block.
+ *
+ * @param {string} clientId The block client ID.
+ * @returns {string} String of the block name, otherwise null.
+ */
+const useBlockName = (clientId) => useSelect(
+  (select) => select(store).getBlockName(clientId),
+  [clientId],
+);
+
+export default useBlockName;

--- a/packages/block-editor-tools/src/hooks/use-parent-block/README.md
+++ b/packages/block-editor-tools/src/hooks/use-parent-block/README.md
@@ -5,9 +5,7 @@ A custom React hook that returns the current block's parent block.
 ## Usage
 
 ```jsx
-const MyBlock = ({
-	clientId
-}) => {
+const MyBlock = ({ clientId }) => {
   const parentBlock = useParentBlock(clientId);
 
   ...

--- a/packages/block-editor-tools/src/hooks/use-parent-block/index.js
+++ b/packages/block-editor-tools/src/hooks/use-parent-block/index.js
@@ -2,13 +2,28 @@ import { store } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
 /**
- * Gets the parent block for a specific block.
+ * Gets the parent block from a specific block.
  *
  * @param {string} clientId The block client ID.
- * @returns {string} String of the parent block, otherwise null.
+ * @returns {Object} Parsed block object, otherwise null.
  */
 const useParentBlock = (clientId) => useSelect(
-  (select) => select(store).getBlockRootClientId(clientId),
+  (select) => {
+    const {
+      getBlock,
+      getBlockRootClientId,
+    } = select(store);
+
+    // Get parent block client ID.
+    const rootBlockClientId = getBlockRootClientId(clientId);
+
+    if (!rootBlockClientId) {
+      return null;
+    }
+
+    // Get parent block.
+    return getBlock(rootBlockClientId);
+  },
   [clientId],
 );
 

--- a/packages/block-editor-tools/src/hooks/use-parent-client-id/README.md
+++ b/packages/block-editor-tools/src/hooks/use-parent-client-id/README.md
@@ -1,0 +1,13 @@
+# Custom Hooks: useParentClientId
+
+A custom React hook that returns the client id of the parent block of the current block.
+
+## Usage
+
+```jsx
+const MyBlock = ({ clientId }) => {
+  const parentBlockClientId = useParentClientId(clientId);
+
+  ...
+};
+```

--- a/packages/block-editor-tools/src/hooks/use-parent-client-id/index.js
+++ b/packages/block-editor-tools/src/hooks/use-parent-client-id/index.js
@@ -1,0 +1,15 @@
+import { store } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Gets the client ID from the parent block of a specific block.
+ *
+ * @param {string} clientId The child block client ID.
+ * @returns {string} String of the parent block client id, otherwise null.
+ */
+const useParentClientId = (clientId) => useSelect(
+  (select) => select(store).getBlockRootClientId(clientId),
+  [clientId],
+);
+
+export default useParentClientId;


### PR DESCRIPTION
### Fixes
- `useParentBlock` - Returns a block instead of the parent client ID.

### New hooks
- `useBlockName` - Get the name of the block using a client ID.
- `useParentClientId` - Get the client ID of a parent block.

## Questions
- This might be a deprecated addition/fix. I'm not sure how people are using the `useParentBlock` but it doesn't return a block but a client id. 
- What about a different name for the client ID version? `useParentBlockID`? `ClientId` seems truer to the returned value.