### PR TITLE
Block Editor Tools: Misc updates

### DIFF
--- a/packages/block-editor-tools/src/hooks/use-debounce/README.md
+++ b/packages/block-editor-tools/src/hooks/use-debounce/README.md
@@ -19,7 +19,7 @@ const MyComponent = () => {
   return (
     <>
       <TextControl
-        label={__('Set Value')}
+        label={__('Set Value', 'your-textdomain-here')}
         onChange={(next) => setValue(next)}
         value={value}
       />

--- a/packages/block-editor-tools/src/hooks/use-debounce/README.md
+++ b/packages/block-editor-tools/src/hooks/use-debounce/README.md
@@ -1,6 +1,8 @@
-# Custom Hooks: usePostMeta
+# Custom Hooks: useDebounce
 
-A custom React hook that creates and returns a new debounced version of the passed value that will postpone its execution until after wait milliseconds have elapsed since the last time it was invoked.
+A custom React hook that creates and returns a new debounced version of the passed value that will postpone its execution until after wait milliseconds have elapsed since the last time it was invoked
+
+@see <https://github.com/alleyinteractive/alley-scripts/issues/250>
 
 ## Usage
 
@@ -17,7 +19,7 @@ const MyComponent = () => {
   return (
     <>
       <TextControl
-        label={__('Set Value', 'alley-scripts')}
+        label={__('Set Value')}
         onChange={(next) => setValue(next)}
         value={value}
       />

--- a/packages/block-editor-tools/src/hooks/use-debounce/index.js
+++ b/packages/block-editor-tools/src/hooks/use-debounce/index.js
@@ -5,6 +5,8 @@ import { useState, useEffect } from '@wordpress/element';
  *
  * @param {string} value value to set at a delay
  * @param {int} delay delay in ms
+ *
+ * @deprecated Use the version from `@uidotdev/usehooks`.
  */
 const useDebounce = (value, delay) => {
   const [debouncedValue, setDebouncedValue] = useState(value);

--- a/packages/block-editor-tools/src/hooks/use-has-inner-blocks/README.md
+++ b/packages/block-editor-tools/src/hooks/use-has-inner-blocks/README.md
@@ -6,14 +6,14 @@ A custom React hook that determines if a block has inner blocks.
 
 ```jsx
 const MyBlock = ({
-	clientId
+ clientId
 }) => {
   const hasInnerBlocks = useHasInnerBlocks(clientId);
 
   if (hasInnerBlocks) {
-	  ...
+    ...
   } else {
-	  ...
+    ...
   }
 
   ...

--- a/packages/block-editor-tools/src/hooks/use-inner-block-index/README.md
+++ b/packages/block-editor-tools/src/hooks/use-inner-block-index/README.md
@@ -7,7 +7,7 @@ within a parent block.
 
 ```jsx
 const MyBlock = ({
-	clientId
+ clientId
 }) => {
   const blockIndex = useInnerBlockIndex(clientId);
 

--- a/packages/block-editor-tools/src/hooks/use-inner-blocks-attributes/README.md
+++ b/packages/block-editor-tools/src/hooks/use-inner-blocks-attributes/README.md
@@ -6,7 +6,7 @@ A custom React hook that returns the current blocks' inner block's attributes.
 
 ```jsx
 const MyBlock = ({
-	clientId
+ clientId
 }) => {
   const innerBlockAttributes = useInnerBlocksAttributes(clientId);
 

--- a/packages/block-editor-tools/src/hooks/use-inner-blocks-attributes/index.js
+++ b/packages/block-editor-tools/src/hooks/use-inner-blocks-attributes/index.js
@@ -4,7 +4,7 @@ import { useInnerBlocks } from '..';
  * Gets all child block attributes for a specific block.
  *
  * @param {string} clientId The block client ID.
- * @returns {Array} An array of child block attributes.
+ * @returns {array} An array of child block attributes.
  */
 const useInnerBlocksAttributes = (clientId) => useInnerBlocks(clientId)
   .map((block) => block.attributes);

--- a/packages/block-editor-tools/src/hooks/use-inner-blocks-count/README.md
+++ b/packages/block-editor-tools/src/hooks/use-inner-blocks-count/README.md
@@ -6,7 +6,7 @@ A custom React hook that returns the current block's inner block count.
 
 ```jsx
 const MyBlock = ({
-	clientId
+ clientId
 }) => {
   const innerBlocksCount = useInnerBlocksCount(clientId);
 

--- a/packages/block-editor-tools/src/hooks/use-inner-blocks/README.md
+++ b/packages/block-editor-tools/src/hooks/use-inner-blocks/README.md
@@ -6,9 +6,9 @@ A custom React hook that returns the current block's inner blocks.
 
 ```jsx
 const MyBlock = ({
-	clientId
+ clientId
 }) => {
-  const blocks = useInnerBlocks(clientId);
+  const innerBlocks = useInnerBlocks(clientId);
 
   ...
 };

--- a/packages/block-editor-tools/src/hooks/use-inner-blocks/index.js
+++ b/packages/block-editor-tools/src/hooks/use-inner-blocks/index.js
@@ -5,7 +5,7 @@ import { useSelect } from '@wordpress/data';
  * Get all children blocks of any given block.
  *
  * @param {string} clientId The block client ID.
- * @returns {Array} An array of child blocks.
+ * @returns {array} An array of child blocks.
  */
 const useInnerBlocks = (clientId) => useSelect(
   (select) => select(store).getBlocks(clientId),

--- a/packages/block-editor-tools/src/hooks/use-parent-block-attributes/README.md
+++ b/packages/block-editor-tools/src/hooks/use-parent-block-attributes/README.md
@@ -6,7 +6,7 @@ A custom React hook that returns the current block's parent block attributes.
 
 ```jsx
 const MyBlock = ({
-	clientId
+ clientId
 }) => {
   const parentBlockAttributes = useParentBlockAttributes(clientId);
 

--- a/packages/block-editor-tools/src/hooks/use-parent-block/index.js
+++ b/packages/block-editor-tools/src/hooks/use-parent-block/index.js
@@ -5,7 +5,7 @@ import { useSelect } from '@wordpress/data';
  * Gets the parent block from a specific block.
  *
  * @param {string} clientId The block client ID.
- * @returns {Object} Parsed block object, otherwise null.
+ * @returns {object} Parsed block object, otherwise null.
  */
 const useParentBlock = (clientId) => useSelect(
   (select) => {

--- a/packages/block-editor-tools/src/hooks/use-post-by-id/README.md
+++ b/packages/block-editor-tools/src/hooks/use-post-by-id/README.md
@@ -7,7 +7,7 @@ If you have the post type, use `usePost` instead.
 
 ```jsx
 const MyBlock = ({
-	postID,
+ postID,
 }) => {
   const post = usePostById(postID);
 
@@ -18,9 +18,10 @@ const MyBlock = ({
 ```
 
 You can also pass a function to lookup the post type when passed the post id.
+
 ```jsx
 const MyBlock = ({
-	postID,
+ postID,
 }) => {
   const myCustomPostTypeLookup = (id) => (
     myCustomPostTypeMap[id]

--- a/packages/block-editor-tools/src/hooks/use-post-by-id/index.js
+++ b/packages/block-editor-tools/src/hooks/use-post-by-id/index.js
@@ -2,12 +2,13 @@ import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import usePost from '../use-post';
+
 /**
  * Gets post data for a specific post given its ID. The post type is
  * looked up from the search endpoint, cached, and then passed to usePost.
  *
- * @param int    postId   The ID for the post to return.
- * @param function getPostType Optional custom function that returns a post type string.
+ * @param {int}      postId   The ID for the post to return.
+ * @param {function} getPostType Optional custom function that returns a post type string.
  * @returns {object} An object containing a hasResolved property
  *                   and the returned post object.
  */
@@ -35,6 +36,7 @@ const usePostById = (postId, getPostType = null) => {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [postId]);
+
   return usePost(postId, postTypeCache[postId] ?? '');
 };
 

--- a/packages/block-editor-tools/src/hooks/use-post-meta-value/README.md
+++ b/packages/block-editor-tools/src/hooks/use-post-meta-value/README.md
@@ -19,7 +19,7 @@ const MyComponent = () => {
 
   return (
     <TextControl
-      label={__('My Meta Key', 'alley-scripts')}
+      label={__('My Meta Key')}
       onChange={setMyMetaKey}
       value={myMetaKey}
     />
@@ -38,7 +38,7 @@ const MyComponent = ({
 
   return (
     <TextControl
-      label={__('My Meta Key', 'alley-scripts')}
+      label={__('My Meta Key')}
       onChange={setMyMetaKey}
       value={myMetaKey}
     />

--- a/packages/block-editor-tools/src/hooks/use-post-meta-value/README.md
+++ b/packages/block-editor-tools/src/hooks/use-post-meta-value/README.md
@@ -19,7 +19,7 @@ const MyComponent = () => {
 
   return (
     <TextControl
-      label={__('My Meta Key')}
+      label={__('My Meta Key', 'your-textdomain-here')}
       onChange={setMyMetaKey}
       value={myMetaKey}
     />
@@ -38,7 +38,7 @@ const MyComponent = ({
 
   return (
     <TextControl
-      label={__('My Meta Key')}
+      label={__('My Meta Key', 'your-textdomain-here')}
       onChange={setMyMetaKey}
       value={myMetaKey}
     />

--- a/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js
+++ b/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js
@@ -1,4 +1,3 @@
-// Internal dependencies.
 import { usePostMeta } from '..';
 
 /**

--- a/packages/block-editor-tools/src/hooks/use-post-meta/README.md
+++ b/packages/block-editor-tools/src/hooks/use-post-meta/README.md
@@ -17,7 +17,7 @@ const MyComponent = () => {
 
   return (
     <TextControl
-      label={__('My Meta Key')}
+      label={__('My Meta Key', 'your-textdomain-here')}
       onChange={(next) => setMeta({ ...meta, my_meta_key: next })}
       value={myMetaKey}
     />
@@ -37,7 +37,7 @@ const MyComponent = ({
 
   return (
     <TextControl
-      label={__('My Meta Key')}
+      label={__('My Meta Key', 'your-textdomain-here')}
       onChange={(next) => setMeta({ ...meta, my_meta_key: next })}
       value={myMetaKey}
     />

--- a/packages/block-editor-tools/src/hooks/use-post-meta/README.md
+++ b/packages/block-editor-tools/src/hooks/use-post-meta/README.md
@@ -17,7 +17,7 @@ const MyComponent = () => {
 
   return (
     <TextControl
-      label={__('My Meta Key', 'alley-scripts')}
+      label={__('My Meta Key')}
       onChange={(next) => setMeta({ ...meta, my_meta_key: next })}
       value={myMetaKey}
     />
@@ -37,7 +37,7 @@ const MyComponent = ({
 
   return (
     <TextControl
-      label={__('My Meta Key', 'alley-scripts')}
+      label={__('My Meta Key')}
       onChange={(next) => setMeta({ ...meta, my_meta_key: next })}
       value={myMetaKey}
     />

--- a/packages/block-editor-tools/src/hooks/use-post/README.md
+++ b/packages/block-editor-tools/src/hooks/use-post/README.md
@@ -6,7 +6,7 @@ A custom React hook to retrieve post data given a post ID and post type.
 
 ```jsx
 const MyBlock = ({
-	postID,
+ postID,
 }) => {
   const post = usePost(postID, postType);
 

--- a/packages/block-editor-tools/src/hooks/use-post/index.js
+++ b/packages/block-editor-tools/src/hooks/use-post/index.js
@@ -3,8 +3,8 @@ import { useSelect } from '@wordpress/data';
 /**
  * Gets post data for a specific post given its ID and post type.
  *
- * @param int    postId   The ID for the post to return.
- * @param string postType Optional. The post type to select. Default 'post'.
+ * @param {int}    postId   The ID for the post to return.
+ * @param {string} postType Optional. The post type to select. Default 'post'.
  * @returns {object} An object containing a hasResolved property
  *                   and the returned post object.
  */

--- a/packages/block-editor-tools/src/hooks/use-posts/README.md
+++ b/packages/block-editor-tools/src/hooks/use-posts/README.md
@@ -6,7 +6,7 @@ A custom React hook to retrieve multiple posts' data given an array of post IDs 
 
 ```jsx
 const MyBlock = ({
-	postIDs,
+ postIDs,
 }) => {
   const posts = usePosts(postIDs, postType);
 

--- a/packages/block-editor-tools/src/hooks/use-terms/README.md
+++ b/packages/block-editor-tools/src/hooks/use-terms/README.md
@@ -1,4 +1,4 @@
-# Custom Hooks: usePostMeta
+# Custom Hooks: useTerms
 
  A custom React hook that wraps useEntityProp for working with a post's terms.
  It returns an array that contains a copy of a post's terms assigned from a
@@ -10,7 +10,7 @@
 
 ## Usage
 
-### Editing the Current Post's Meta
+### Editing the Current Post's Terms
 
 ```jsx
 const MyComponent = ({
@@ -20,17 +20,17 @@ const MyComponent = ({
 
   return (
     <SelectControl
-      label={__('My Terms', 'board-connect')}
-	  multiple
+      label={__('My Terms')}
+      multiple
       onChange={(next) => setTerms(next)}
-	  options={options}
+      options={options}
       value={terms}
     />
   );
 };
 ```
 
-### Editing Another Post's Meta
+### Editing Another Post's Terms
 
 ```jsx
 const MyComponent = ({
@@ -42,10 +42,10 @@ const MyComponent = ({
 
   return (
     <SelectControl
-      label={__('My Terms', 'board-connect')}
-	  multiple
+      label={__('My Terms')}
+      multiple
       onChange={(next) => setTerms(next)}
-	  options={options}
+      options={options}
       value={terms}
     />
   );

--- a/packages/block-editor-tools/src/hooks/use-terms/README.md
+++ b/packages/block-editor-tools/src/hooks/use-terms/README.md
@@ -20,7 +20,7 @@ const MyComponent = ({
 
   return (
     <SelectControl
-      label={__('My Terms')}
+      label={__('My Terms', 'your-textdomain-here')}
       multiple
       onChange={(next) => setTerms(next)}
       options={options}
@@ -42,7 +42,7 @@ const MyComponent = ({
 
   return (
     <SelectControl
-      label={__('My Terms')}
+      label={__('My Terms', 'your-textdomain-here')}
       multiple
       onChange={(next) => setTerms(next)}
       options={options}


### PR DESCRIPTION
- [x] Update docs;
- [x] Remove the text domains from the examples;
- [x] Deprecate the `useDecounce` hook. Mainly to warn users it'll be removed. See #250 
- [x] Update DocBlock