### PR TITLE
Block Editor Tools: `useInnerBlocks` return child blocks instead of the parent block

### DIFF
--- a/packages/block-editor-tools/src/hooks/use-inner-blocks/index.js
+++ b/packages/block-editor-tools/src/hooks/use-inner-blocks/index.js
@@ -8,7 +8,7 @@ import { useSelect } from '@wordpress/data';
  * @returns {Array} An array of child blocks.
  */
 const useInnerBlocks = (clientId) => useSelect(
-  (select) => select(store).getBlocks(clientId),
+  (select) => select(store).getBlocks(clientId)[0]?.innerBlocks || [],
   [clientId],
 );
 


### PR DESCRIPTION
Based on its name and description, `useInnerBlocks` should be returning the array of inner blocks but it currently returns the parent block IF the block has inner blocks or an empty `array` if the block does not have inner blocks.

<img width="1797" alt="Screenshot 2023-08-14 at 00 51 56" src="https://github.com/alleyinteractive/alley-scripts/assets/19148962/4ba92c1b-6c2c-4b0a-9d12-a17086a647a3">

So it works sort of a line a `useHasInnerBlocks`. This hook is used in other hooks internally, in the `useInnerBlockIndex`, etc. 

I assume this worked before correctly or people assumed it worked before since it returned the parent block inside an `array`, instead of the child/inner blocks. But the current behavior is not accurate, IMO.

For Alley devs: we have [many instances](https://l.alley.dev/e0a4d4953c), or copies, of this block we might need to update or confirm if they are behaving properly.
