### PR TITLE
Only run GitHub Actions on non-draft PRs against main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
 name: CI
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   build:
+      if: github.event.pull_request.draft == false
       name: Build and Test
       timeout-minutes: 15
       runs-on: ubuntu-latest

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,16 +1,14 @@
 name: Coding Standards
 
 on:
-  push:
-    branches:
-      - develop
-      - main
   pull_request:
-  schedule:
-    - cron: '0 0 * * *'
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   coding-standards:
+    if: github.event.pull_request.draft == false
     uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main
     with:
       working-directory: plugin


### PR DESCRIPTION
- Eliminates unnecessary runs of CI checks on merge
- Prevents CI checks from running against draft PRs
- Eliminates the schedule for phpcs checks, which only applies to one component of this monorepo, in favor of using PR checks exclusively