### PR TITLE
Add allowExpressions for children in fragments in TS/React

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 - 2023-08-16
+
+- Add `allowExpressions` to `react/jsx-no-useless-fragment` rule to allow for `<>{children}</>` syntax, which is
+  necessary for satisfying the TypeScript compiler when the exact shape of `children` is unknown.
+
+## 0.1.1 - 2023-08-05
+
+- Bump `@typescript-eslint/parser` from 6.2.0 to 6.2.1.
+
 ## 0.1.0 - 2023-03-29
 
 - Reorder ESLint extends in `/typescript-react` to ensure proper rules are followed.

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -60,5 +60,5 @@
   "scripts": {
     "lint": "eslint ."
   },
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/packages/eslint-config/typescript-react/index.js
+++ b/packages/eslint-config/typescript-react/index.js
@@ -13,6 +13,7 @@ module.exports = {
   ],
   rules: {
     'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.tsx'] }],
+    'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
     'react/require-default-props': 'off',
   },
 };


### PR DESCRIPTION
Problem:

The following code throws a TypeScript error:

```tsx
  return (
    <div {...innerBlocksProps}>
      <h2>Section Title Goes Here</h2>
      {children}
    </div>
  );
```

The issue is with the `children` item, whereby TypeScript doesn't (and in this case, can't) know the shape of `children` and therefore throws the following error:

```
TS2322: Type  unknown  is not assignable to type  ReactNode
```

The recommended way of dealing with this is to wrap it in a fragment, like this:

```tsx
  return (
    <div {...innerBlocksProps}>
      <h2>Section Title Goes Here</h2>
      <>{children}</>
    </div>
  );
```

However, this causes ESLint to throw an error about a "useless fragment" in JSX, even though the fragment has a use in this case (specifically, TypeScript).

There is an option to allow a fragment when the fragment contains an expression, as in the case above, specifically for this reason: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md

This change enables this flag for the typescript/react flavor of the rules specifically.