### PR TITLE
Let block registration flow from block.json

### DIFF
--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alleyinteractive/create-block",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Alley's custom block scaffolding variation for the @wordpress/create-block script.",
   "main": "index.js",
   "scripts": {

--- a/packages/create-block/templates/javascript/index.js.mustache
+++ b/packages/create-block/templates/javascript/index.js.mustache
@@ -4,12 +4,4 @@ import metadata from './block.json';
 
 import './style.scss';
 
-/**
- * Registration for the {{namespace}}/{{slug}} block.
- */
-registerBlockType(
-  metadata.name,
-  {
-    edit,
-  },
-);
+registerBlockType(metadata.name, { edit });

--- a/packages/create-block/templates/javascript/index.js.mustache
+++ b/packages/create-block/templates/javascript/index.js.mustache
@@ -4,4 +4,4 @@ import metadata from './block.json';
 
 import './style.scss';
 
-registerBlockType(metadata.name, { edit });
+registerBlockType(metadata, { edit });

--- a/packages/create-block/templates/typescript/index.ts.mustache
+++ b/packages/create-block/templates/typescript/index.ts.mustache
@@ -5,15 +5,5 @@ import metadata from './block.json';
 
 import './style.scss';
 
-/**
- * Registration for the {{namespace}}/{{slug}} block.
- */
-registerBlockType(
-  /* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
-  metadata,
-  {
-    apiVersion: 2,
-    edit,
-    title: metadata.title,
-  },
-);
+/* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+registerBlockType(metadata, { edit });


### PR DESCRIPTION
- block.json handles the aspects we care about during block registration, including `apiVersion` and `title`, so we don't need to include them in the TypeScript template (the JS template already works this way). This fixes an issue where the `apiVersion` parameter might not match between what is scaffolded here and what is in block.json (see the recent update from version 2 to 3).
- Eliminates the comment above the registration. It's clear what the function call is doing from its context and the comment isn't necessary.