### PR TITLE
Remove Dependency on Chalk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34164,7 +34164,7 @@
     },
     "packages/block-editor-tools": {
       "name": "@alleyinteractive/block-editor-tools",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@alleyinteractive/tsconfig": "*",
@@ -35105,10 +35105,9 @@
     },
     "packages/create-block": {
       "name": "@alleyinteractive/create-block",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "chalk": "^5.3.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
         "cross-spawn": "^7.0.3",
@@ -35253,7 +35252,7 @@
     },
     "packages/eslint-config": {
       "name": "@alleyinteractive/eslint-config",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": ">= 7",
@@ -37030,7 +37029,6 @@
         "@types/cross-spawn": "^6.0.2",
         "@types/node": "^20.4.10",
         "@types/prompts": "^2.4.4",
-        "chalk": "^5.3.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
         "cross-spawn": "^7.0.3",

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.0.3 - 2023-08-17
+
+- Bugfix: Remove dependency on `chalk`, which was bumped to v5 by Dependabot, and is not compatible with TypeScript.
+
+## 0.0.2 - 2023-08-16
+
+- Simplify `registerBlockType` function calls to pull all metadata from block.json and prevent the need for updating
+  certain types of metadata (like apiVersion) in multiple places.
+
+## 0.0.1 - 2023-05-30
+
+- Initial version. Contains JavaScript and TypeScript variants.

--- a/packages/create-block/index.ts
+++ b/packages/create-block/index.ts
@@ -4,7 +4,6 @@ const fs = require('fs');
 const prompts = require('prompts');
 const path = require('path');
 const spawn = require('cross-spawn');
-const chalk = require('chalk');
 const commandLineArgs = require('command-line-args');
 const commandLineUsage = require('command-line-usage');
 
@@ -63,11 +62,7 @@ const options: Options[] = [
  */
 function validateBlockLanguage(value: string) {
   if (value !== 'typescript' && value !== 'javascript') {
-    throw new Error(
-      chalk.red(
-        'The block language must be one of \'typescript\' or \'javascript\'\n',
-      ),
-    );
+    throw new Error('The block language must be one of \'typescript\' or \'javascript\'\n');
   }
   return value;
 }
@@ -135,9 +130,9 @@ if (help) {
   if (!fs.existsSync(blocksDirectory)) {
     try {
       fs.mkdirSync(blocksDirectory);
-      console.log(chalk.cyan(`Directory '${blocksDirectory}' created successfully!\n`));
+      console.log(`Directory '${blocksDirectory}' created successfully!\n`);
     } catch (error: any) {
-      console.error(chalk.red(`Failed to create directory '${blocksDirectory}'`), error);
+      console.error(`Failed to create directory '${blocksDirectory}'`, error);
       process.exit(1); // Exit the script with an error status code
     }
   }

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alleyinteractive/create-block",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Alley's custom block scaffolding variation for the @wordpress/create-block script.",
   "main": "index.js",
   "scripts": {
@@ -32,7 +32,6 @@
   },
   "homepage": "https://github.com/alleyinteractive/alley-scripts/tree/main/packages/create-block",
   "dependencies": {
-    "chalk": "^5.3.0",
     "command-line-args": "^5.2.1",
     "command-line-usage": "^7.0.1",
     "cross-spawn": "^7.0.3",


### PR DESCRIPTION
Dependabot bumped Chalk to v5 after the release of v0.0.1, and the new version shipped with v0.0.2 yesterday, which introduced a breaking change due to Chalk v5 being incompatible with TypeScript. Chalk's maintainers advise using Chalk v4 "for now," but since Dependabot bumped the version to v5 due to a security issue, I'm removing Chalk altogether at this time to get this package working again. We can evaluate a path forward (either using Chalk or something else) in the future.