### PR TITLE
Feature/suppress post ids

### DIFF
--- a/packages/block-editor-tools/package.json
+++ b/packages/block-editor-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alleyinteractive/block-editor-tools",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A set of tools to help build products for the WordPress block editor.",
   "main": "./build/index.bundle.min.js",
   "types": "./build/index.d.ts",

--- a/packages/block-editor-tools/src/components/post-picker/README.md
+++ b/packages/block-editor-tools/src/components/post-picker/README.md
@@ -32,5 +32,6 @@ results, and a custom function for fetching post data given a post ID.
 | previewRender  |                | No       | function | Optional component to render the preview of the selected post. Must recieve an object similar to what is returned from the `/wp/v2/posts/<ID>` endpoint. |
 | searchEndpoint | `/wp/v2/search` | No | string | Optional search endpoint. |
 | searchRender   |                | No       | function | Optional component to render the preview of posts in the modal window. Must recieve an object similar to what is returned from the `/wp/v2/search` endpoint. |
+| suppressPostIds |                | No       | array    | Array of post ids to not show in the results list. |
 | title          | `''`           | No       | string   | Optional title for the component. |
 | value          |                | Yes      | integer  | The ID of the selected post. 0 represents no selection.                                                   |

--- a/packages/block-editor-tools/src/components/post-picker/index.tsx
+++ b/packages/block-editor-tools/src/components/post-picker/index.tsx
@@ -25,6 +25,7 @@ interface PostPickerProps {
   previewRender?: (post: object | WP_REST_API_Post) => JSX.Element;
   searchEndpoint?: string;
   searchRender?: (post: object) => JSX.Element;
+  suppressPostIds?: number[];
   title?: string;
   value: number;
 }
@@ -54,6 +55,7 @@ const PostPicker = ({
   previewRender,
   searchEndpoint = '/wp/v2/search',
   searchRender,
+  suppressPostIds = [],
   title: pickerTitle = '',
   value = 0,
 }: PostPickerProps) => {
@@ -153,6 +155,7 @@ const PostPicker = ({
           baseUrl={baseUrl}
           onUpdate={onUpdate}
           searchRender={searchRender}
+          suppressPostIds={suppressPostIds}
         />
       ) : null}
     </Container>

--- a/packages/block-editor-tools/src/components/post-picker/post-list.tsx
+++ b/packages/block-editor-tools/src/components/post-picker/post-list.tsx
@@ -14,6 +14,7 @@ interface PostListProps {
   searchRender?: (post: object) => JSX.Element;
   selected?: number;
   setSelected: (id: number) => void;
+  suppressPostIds?: number[];
 }
 
 interface Params {
@@ -31,6 +32,7 @@ const PostList = ({
   searchRender,
   selected,
   setSelected,
+  suppressPostIds = [],
 }: PostListProps) => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [listposts, setListposts] = useState<WP_REST_API_Search_Results>([]);
@@ -150,27 +152,32 @@ const PostList = ({
       />
       <div className="alley-scripts-post-picker__post-list">
         {listposts ? (
-          listposts.map((t) => (
-            <Button
-              key={t.id}
-              className={classNames({
-                'alley-scripts-post-picker__post': true,
-                'is-selected': t.id === selected,
-              })}
-              onClick={() => setSelected(t.id as number)}
-            >
-              {searchRender ? (
-                searchRender(t)
-              ) : (
-                <Post
-                  title={t.title}
-                  postType={t.subtype}
-                    // eslint-disable-next-line no-underscore-dangle
-                  attachmentID={t?._embedded?.self[0]?.featured_media}
-                />
-              )}
-            </Button>
-          ))
+          listposts.map((t) => {
+            if (suppressPostIds.includes(t.id as number)) {
+              return null;
+            }
+            return (
+              <Button
+                key={t.id}
+                className={classNames({
+                  'alley-scripts-post-picker__post': true,
+                  'is-selected': t.id === selected,
+                })}
+                onClick={() => setSelected(t.id as number)}
+              >
+                {searchRender ? (
+                  searchRender(t)
+                ) : (
+                  <Post
+                    title={t.title}
+                    postType={t.subtype}
+                      // eslint-disable-next-line no-underscore-dangle
+                    attachmentID={t?._embedded?.self[0]?.featured_media}
+                  />
+                )}
+              </Button>
+            );
+          })
         ) : null}
         {isUpdating ? (
           <Spinner />

--- a/packages/block-editor-tools/src/components/post-picker/post-list.tsx
+++ b/packages/block-editor-tools/src/components/post-picker/post-list.tsx
@@ -62,6 +62,7 @@ const PostList = ({
         {
           page: params.page,
           _embed: 1,
+          exclude: suppressPostIds.join(','),
         },
       );
       if (params.searchValue && params.searchValue.length > 2) {
@@ -101,7 +102,7 @@ const PostList = ({
     // @ts-ignore
     setListposts(posts as any as WP_REST_API_Search_Results);
     setIsUpdating(false);
-  }, [listposts, baseUrl]);
+  }, [listposts, baseUrl, suppressPostIds]);
 
   /**
    * Loads more posts.
@@ -152,32 +153,27 @@ const PostList = ({
       />
       <div className="alley-scripts-post-picker__post-list">
         {listposts ? (
-          listposts.map((t) => {
-            if (suppressPostIds.includes(t.id as number)) {
-              return null;
-            }
-            return (
-              <Button
-                key={t.id}
-                className={classNames({
-                  'alley-scripts-post-picker__post': true,
-                  'is-selected': t.id === selected,
-                })}
-                onClick={() => setSelected(t.id as number)}
-              >
-                {searchRender ? (
-                  searchRender(t)
-                ) : (
-                  <Post
-                    title={t.title}
-                    postType={t.subtype}
-                      // eslint-disable-next-line no-underscore-dangle
-                    attachmentID={t?._embedded?.self[0]?.featured_media}
-                  />
-                )}
-              </Button>
-            );
-          })
+          listposts.map((t) => (
+            <Button
+              key={t.id}
+              className={classNames({
+                'alley-scripts-post-picker__post': true,
+                'is-selected': t.id === selected,
+              })}
+              onClick={() => setSelected(t.id as number)}
+            >
+              {searchRender ? (
+                searchRender(t)
+              ) : (
+                <Post
+                  title={t.title}
+                  postType={t.subtype}
+                    // eslint-disable-next-line no-underscore-dangle
+                  attachmentID={t?._embedded?.self[0]?.featured_media}
+                />
+              )}
+            </Button>
+          ))
         ) : null}
         {isUpdating ? (
           <Spinner />

--- a/packages/block-editor-tools/src/components/post-picker/search-modal.tsx
+++ b/packages/block-editor-tools/src/components/post-picker/search-modal.tsx
@@ -15,6 +15,7 @@ interface SearchModalProps {
   closeModal: () => void;
   onUpdate: (id: number) => void;
   searchRender?: (post: object) => JSX.Element;
+  suppressPostIds?: number[];
 }
 
 const SearchModal = ({
@@ -22,6 +23,7 @@ const SearchModal = ({
   closeModal,
   onUpdate,
   searchRender,
+  suppressPostIds = [],
 }: SearchModalProps) => {
   const [selected, setSelected] = useState<number>();
 
@@ -45,6 +47,7 @@ const SearchModal = ({
         selected={selected ?? 0}
         setSelected={setSelected}
         searchRender={searchRender}
+        suppressPostIds={suppressPostIds}
       />
       <div className="alley-scripts-post-picker__buttons">
         <Button


### PR DESCRIPTION
adds parameter to PostPicker to hide post ids from the search results
best viewed with [white space disabled](https://github.com/alleyinteractive/alley-scripts/pull/348/files?diff=unified&w=1) 

addresses https://github.com/alleyinteractive/alley-scripts/issues/347