### PR TITLE
Dont modify package.json/composer.json unless requested

### DIFF
--- a/.changeset/silly-planes-grow.md
+++ b/.changeset/silly-planes-grow.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/create-release": patch
+---
+
+Only modify the plugin's header by default. Don't modify the `composer.json`/`package.json` version unless `--composer`/`--npm` is passed.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This monorepo contains the following packages:
 - [`@alleyinteractive/block-editor-tools`](./packages/block-editor-tools/README.md)
 - [`@alleyinteractive/create-block`](./packages/create-block/README.md)
 - [`@alleyinteractive/create-entry`](./packages/create-entry/README.md)
+- [`@alleyinteractive/create-release`](./packages/create-release/README.md)
 - [`@alleyinteractive/eslint-config`](./packages/eslint-config/README.md)
 - [`@alleyinteractive/stylelint-config`](./packages/stylelint-config/README.md)
 - [`@alleyinteractive/tsconfig`](./packages/tsconfig/README.md)

--- a/packages/create-release/CHANGELOG.md
+++ b/packages/create-release/CHANGELOG.md
@@ -1,15 +1,13 @@
 # Changelog
 
-## 0.1.2
-
-### Patch Changes
-
-- b13adef: No change, re-release with a license and README.
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.2
+
+- No change, re-release with a license and README.
 
 ## 0.1.1 - 2023-09-19
 

--- a/packages/create-release/README.md
+++ b/packages/create-release/README.md
@@ -26,6 +26,8 @@ following arguments are available:
   --minor              Bump the minor version number.
   --patch              Bump the patch version number.
   -p, --path string    The path to the plugin. Supports relative and absolute paths.
+  --composer           Update the version in the plugin's composer.json file.
+  --npm                Update the version in the plugin's package.json file.
   --dry-run            Run the command without making any changes.
   -h, --help           Prints help information.
 ```

--- a/packages/create-release/README.md
+++ b/packages/create-release/README.md
@@ -3,11 +3,13 @@
 This action facilitates the release process of a
 [Create WordPress Plugin](https://github.com/alleyinteractive/create-wordpress-plugin) plugin.
 
-When run, it will trigger a new version to be set in the plugin's
-`composer.json` and plugin's header. This sets up the [GitHub Action
-workflow](https://github.com/alleyinteractive/create-wordpress-plugin/blob/HEAD/.github/workflows/built-release.yml)
+When run, it will trigger a new version to be set in the plugin's header and
+optionally in the plugin's `composer.json`/`package.json` files. This sets up
+the [GitHub Action workflow](https://github.com/alleyinteractive/create-wordpress-plugin/blob/HEAD/.github/workflows/built-release.yml)
 which listens for a new version to automatically build and publish to Git.
-Running this package's command is optional and can be done manually by the user.
+Running this package's command is optional and the work can still be done
+manually by the user but does aim to make it easier to develop and release
+new versions of a plugin.
 
 ## Usage
 

--- a/packages/create-release/README.md
+++ b/packages/create-release/README.md
@@ -7,9 +7,13 @@ When run, it will trigger a new version to be set in the plugin's header and
 optionally in the plugin's `composer.json`/`package.json` files. This sets up
 the [GitHub Action workflow](https://github.com/alleyinteractive/create-wordpress-plugin/blob/HEAD/.github/workflows/built-release.yml)
 which listens for a new version to automatically build and publish to Git.
+
+
 Running this package's command is optional and the work can still be done
-manually by the user but does aim to make it easier to develop and release
-new versions of a plugin.
+manually by the user but does aim to make it easier to develop and release new
+versions of a plugin. The command does not commit or push any changes to Git,
+only changing the local files and deferring to the user to commit and push
+changes to Git.
 
 ## Usage
 

--- a/packages/create-release/index.ts
+++ b/packages/create-release/index.ts
@@ -20,6 +20,7 @@ import {
   getCurrentVersion,
   getReleaseType,
   upgradeComposerVersion,
+  upgradeNpmPackageVersion,
   upgradePluginVersion,
   upgradeReadmeVersion,
 } from './src/helpers.js';
@@ -45,6 +46,8 @@ import {
 
   const {
     'dry-run': dryRun = false,
+    composer: updateComposer = false,
+    npm: updateNpm = false,
   } = entryArgs;
 
   if (dryRun) {
@@ -147,16 +150,32 @@ import {
     process.exit(1);
   }
 
-  // Update the version in Composer.json.
-  if (dryRun) {
-    console.log(`Would be updating "version" in ${chalk.yellow('composer.json')} to ${chalk.yellow(releaseVersion)}`);
-  } else {
-    upgradeComposerVersion(
-      basePath,
-      releaseVersion,
-    );
+  // Update the version in composer.json.
+  if (updateComposer) {
+    if (dryRun) {
+      console.log(`Would be updating "version" in ${chalk.yellow('composer.json')} to ${chalk.yellow(releaseVersion)}`);
+    } else {
+      upgradeComposerVersion(
+        basePath,
+        releaseVersion,
+      );
 
-    console.log(`Updated "version" in ${chalk.yellow('composer.json')} to ${chalk.yellow(releaseVersion)}`);
+      console.log(`Updated "version" in ${chalk.yellow('composer.json')} to ${chalk.yellow(releaseVersion)}`);
+    }
+  }
+
+  // Update the version in package.json.
+  if (updateNpm) {
+    if (dryRun) {
+      console.log(`Would be updating "version" in ${chalk.yellow('package.json')} to ${chalk.yellow(releaseVersion)}`);
+    } else {
+      upgradeNpmPackageVersion(
+        basePath,
+        releaseVersion,
+      );
+
+      console.log(`Updated "version" in ${chalk.yellow('package.json')} to ${chalk.yellow(releaseVersion)}`);
+    }
   }
 
   // Update the version in the plugin header.

--- a/packages/create-release/src/entryArgs.ts
+++ b/packages/create-release/src/entryArgs.ts
@@ -9,6 +9,8 @@ export type EntryArgs = {
   minor?: boolean;
   patch?: boolean;
   path?: string;
+  composer?: boolean;
+  npm?: boolean;
   'dry-run'?: boolean;
   help?: boolean;
 };
@@ -43,6 +45,16 @@ const entryArgs = parse<EntryArgs>(
       type: String,
       alias: 'p',
       description: 'The path to the plugin.',
+      optional: true,
+    },
+    composer: {
+      type: Boolean,
+      description: 'Update the composer.json file version.',
+      optional: true,
+    },
+    npm: {
+      type: Boolean,
+      description: 'Update the package.json file version.',
       optional: true,
     },
     'dry-run': {


### PR DESCRIPTION
The `composer.json`/`package.json` file should not be updated unless requested. This change is to make the version not primarily tracked in the `composer.json` file.

Related https://github.com/alleyinteractive/.github/pull/56
