### PR TITLE
Add "rules" dir to published files in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42611,7 +42611,7 @@
     },
     "packages/eslint-config": {
       "name": "@alleyinteractive/eslint-config",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": ">= 7",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,6 +34,7 @@
     "base",
     "configs",
     "parsers",
+    "rules",
     "typescript",
     "typescript-react"
   ],
@@ -60,7 +61,7 @@
   "scripts": {
     "lint": "eslint ."
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "devDependencies": {
     "@types/node": "^20.6.0"
   }


### PR DESCRIPTION
This is a fix where the new directory "rules" was not added to the published files on npm.