### PR TITLE
Added `useCurrentPostId` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to the Alley Scripts monorepo will be documented in this fil
 
 - Initial release.
 
+## v0.3.7 -- @alleyinteractive/block-editor-tools
+
+- added `useCurrentPostId` hook.
+
 ## v0.3.0 -- @alleyinteractive/block-editor-tools
 
 - added `<PostPicker>` component and `usePostById` hook.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ When you're finished with the changes, create a pull request, also known as a PR
   [git tutorial](https://github.com/skills/resolve-merge-conflicts) to help you
   resolve merge conflicts and other issues.
 
-#### Your PR is Merged!
+#### Your PR is Merged
 
 Congratulations! The Alley team thanks you.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ When you're finished with the changes, create a pull request, also known as a PR
   [git tutorial](https://github.com/skills/resolve-merge-conflicts) to help you
   resolve merge conflicts and other issues.
 
-#### Your PR is Merged
+#### Your PR is Merged!
 
 Congratulations! The Alley team thanks you.
 

--- a/packages/block-editor-tools/README.md
+++ b/packages/block-editor-tools/README.md
@@ -10,8 +10,8 @@ This package contains a set of modules used by [Alley Interactive](https://alley
 - [Usage](#usage)
 - [Changelog](#changelog)
 - [Development Process](#development-process)
-    - [Contributing](#contributing)
-	- [Releases](#Releases)
+  - [Contributing](#contributing)
+- [Releases](#releases)
 - [Maintainers](#maintainers)
 - [License](#license)
 
@@ -29,24 +29,28 @@ This package assumes your project is running in an environment compatible with t
 
 To use modules from this package, import them into your files using the `import` declaration
 
-```js
+```jsx
 import { usePostMeta } from '@alleyinteractive/block-editor-tools';
 
 const MyComponent = () => {
-	const [meta, setMeta] = usePostMeta();
-	const { my_meta_key: myMetaKey } = meta;
+ const [meta, setMeta] = usePostMeta();
+ const { my_meta_key: myMetaKey } = meta;
 
-	return (
-		<TextControl
-			label={__('My Meta Key', 'alley-scripts')}
-			onChange={(newValue) => setMeta({ ...meta, my_meta_key: newValue })}
-			value={myMetaKey}
-		/>
-	);
+ return (
+  <TextControl
+   label={__('My Meta Key', 'alley-scripts')}
+   onChange={(newValue) => setMeta({ ...meta, my_meta_key: newValue })}
+   value={myMetaKey}
+  />
+ );
 };
 ```
 
 ## Changelog
+
+### 0.3.7
+
+- Addition of `useCurrentPostId` hook.
 
 ### 0.3.0
 
@@ -72,8 +76,8 @@ This package is developed as part of the [Alley Scripts](https://github.com/alle
 
 You can contribute to this project in several ways:
 
-* Visit the main [Alley Scripts GitHub repo](https://github.com/alleyinteractive/alley-scripts) to [Open an issue](https://github.com/alleyinteractive/alley-scripts/issues/new) or submit PRs.
-* Alley employees can ask questions or ask for support in the [#javascript](https://alleyinteractive.slack.com/archives/C035Y7Q3X) channel in Slack.
+- Visit the main [Alley Scripts GitHub repo](https://github.com/alleyinteractive/alley-scripts) to [Open an issue](https://github.com/alleyinteractive/alley-scripts/issues/new) or submit PRs.
+- Alley employees can ask questions or ask for support in the [#javascript](https://alleyinteractive.slack.com/archives/C035Y7Q3X) channel in Slack.
 
 ### Releases
 

--- a/packages/block-editor-tools/README.md
+++ b/packages/block-editor-tools/README.md
@@ -4,17 +4,6 @@
 
 This package contains a set of modules used by [Alley Interactive](https://alley.co) to aid in building features for the WordPress block editor.
 
-## Table of Contents
-
-- [Install](#install)
-- [Usage](#usage)
-- [Changelog](#changelog)
-- [Development Process](#development-process)
-  - [Contributing](#contributing)
-- [Releases](#releases)
-- [Maintainers](#maintainers)
-- [License](#license)
-
 ## Install
 
 Install this package in your project:
@@ -33,16 +22,16 @@ To use modules from this package, import them into your files using the `import`
 import { usePostMeta } from '@alleyinteractive/block-editor-tools';
 
 const MyComponent = () => {
- const [meta, setMeta] = usePostMeta();
- const { my_meta_key: myMetaKey } = meta;
+  const [meta, setMeta] = usePostMeta();
+  const { my_meta_key: myMetaKey } = meta;
 
- return (
-  <TextControl
-   label={__('My Meta Key', 'alley-scripts')}
-   onChange={(newValue) => setMeta({ ...meta, my_meta_key: newValue })}
-   value={myMetaKey}
-  />
- );
+  return (
+    <TextControl
+      label={__('My Meta Key', 'alley-scripts')}
+      value={myMetaKey}
+      onChange={(newValue) => setMeta({ ...meta, my_meta_key: newValue })}
+    />
+  );
 };
 ```
 
@@ -77,7 +66,6 @@ This package is developed as part of the [Alley Scripts](https://github.com/alle
 You can contribute to this project in several ways:
 
 - Visit the main [Alley Scripts GitHub repo](https://github.com/alleyinteractive/alley-scripts) to [Open an issue](https://github.com/alleyinteractive/alley-scripts/issues/new) or submit PRs.
-- Alley employees can ask questions or ask for support in the [#javascript](https://alleyinteractive.slack.com/archives/C035Y7Q3X) channel in Slack.
 
 ### Releases
 

--- a/packages/block-editor-tools/package.json
+++ b/packages/block-editor-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alleyinteractive/block-editor-tools",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A set of tools to help build products for the WordPress block editor.",
   "main": "./build/index.bundle.min.js",
   "types": "./build/index.d.ts",

--- a/packages/block-editor-tools/src/hooks/index.js
+++ b/packages/block-editor-tools/src/hooks/index.js
@@ -8,6 +8,7 @@ export { default as useMedia } from './use-media';
 export { default as useParentBlock } from './use-parent-block';
 export { default as useParentBlockAttributes } from './use-parent-block-attributes';
 export { default as usePost } from './use-post';
+export { default as useCurrentPostId } from './use-current-post-id';
 export { default as usePostById } from './use-post-by-id';
 export { default as usePostMeta } from './use-post-meta';
 export { default as usePostMetaValue } from './use-post-meta-value';

--- a/packages/block-editor-tools/src/hooks/use-current-post-id/README.md
+++ b/packages/block-editor-tools/src/hooks/use-current-post-id/README.md
@@ -1,0 +1,15 @@
+# Custom Hooks: useCurrentPostId
+
+A custom React hook to retrieve the current post ID.
+
+## Usage
+
+```jsx
+const MyBlock = () => {
+  const currentPostID = useCurrentPostId();
+
+  if (currentPostID) {
+    ...
+  }
+};
+```

--- a/packages/block-editor-tools/src/hooks/use-current-post-id/index.js
+++ b/packages/block-editor-tools/src/hooks/use-current-post-id/index.js
@@ -5,6 +5,9 @@ import { useSelect } from '@wordpress/data';
  *
  * @returns {integer} The current post ID.
  */
-const useCurrentPostId = () => useSelect((select) => select('core/editor').getCurrentPostId(), []);
+const useCurrentPostId = () => useSelect((select) => {
+  const editorStore = select('core/editor');
+  return editorStore ? editorStore.getCurrentPostId() : null;
+}, []);
 
 export default useCurrentPostId;

--- a/packages/block-editor-tools/src/hooks/use-current-post-id/index.js
+++ b/packages/block-editor-tools/src/hooks/use-current-post-id/index.js
@@ -1,0 +1,10 @@
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Gets the current post ID.
+ *
+ * @returns {integer} The current post ID.
+ */
+const useCurrentPostId = () => useSelect((select) => select('core/editor').getCurrentPostId(), []);
+
+export default useCurrentPostId;

--- a/packages/block-editor-tools/src/hooks/use-current-post-id/index.js
+++ b/packages/block-editor-tools/src/hooks/use-current-post-id/index.js
@@ -3,7 +3,9 @@ import { useSelect } from '@wordpress/data';
 /**
  * Gets the current post ID.
  *
- * @returns {integer} The current post ID.
+ * @returns {?number} Returns the ID of the post currently being edited,
+ *                    or null if the post has not yet been saved or the redux store
+ *                    is not initialized.
  */
 const useCurrentPostId = () => useSelect((select) => {
   const editorStore = select('core/editor');


### PR DESCRIPTION
- As titled;
- Tweaks to the READM.md to fix some violations;
- Bumping version.

It's not clear where the source of the changelog is. So I updated in both places just in case. Both options don't seem to be respected, considering the lack of notes there. ¯\_(ツ)_/¯

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced a new tool, `useCurrentPostId`, to the `@alleyinteractive/block-editor-tools` package. This tool allows developers to easily retrieve the ID of the current post being edited in a WordPress environment, enhancing the customization and functionality of their components.
- Documentation: Updated the package documentation and code examples to reflect the new feature and made minor textual modifications for clarity. Removed the table of contents and Slack channel support for Alley employees.
- Style: Made a minor change to the pull request message format for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->