### PR TITLE
Update documentation and add exports for webpack configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39591,7 +39591,7 @@
     },
     "packages/build-tool": {
       "name": "@alleyinteractive/build-tool",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/scripts": "^26.6.4",

--- a/packages/build-tool/CHANGELOG.md
+++ b/packages/build-tool/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v0.1.1 -- @alleyinteractive/build-tool
 
-- Add `--webpack-blocks-only` that will will disable the entries directory and only compile blocks set in the `blocks` directory.
+- Add `--webpack-blocks-only` that will disable the entries directory and only compile blocks set in the `blocks` directory.
 - Update ESLint config to extend `@alleyinteractive/eslint-config/typescript` config.
 - Add a `prepublishOnly` script to the `package.json` file to run `npm run build` before publishing.
 

--- a/packages/build-tool/CHANGELOG.md
+++ b/packages/build-tool/CHANGELOG.md
@@ -5,14 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.0.1-beta -- @alleyinteractive/build-tool
+## v0.1.2 -- @alleyinteractive/build-tool
 
-- initial beta publication of Alley Build Tool.
+- Add exports for webpack config and update README with instructions on how to extend the config.
+
+## v0.1.1 -- @alleyinteractive/build-tool
+
+- Add `--webpack-blocks-only` that will will disable the entries directory and only compile blocks set in the `blocks` directory.
+- Update ESLint config to extend `@alleyinteractive/eslint-config/typescript` config.
+- Add a `prepublishOnly` script to the `package.json` file to run `npm run build` before publishing.
+
+## v0.1.0 -- @alleyinteractive/build-tool
+
+- initial stable publication of Alley Build Tool.
 
 ## v0.0.2-beta -- @alleyinteractive/build-tool
 
 - Add utils to published files.
 
-## v0.1.0 -- @alleyinteractive/build-tool
+## v0.0.1-beta -- @alleyinteractive/build-tool
 
-- initial stable publication of Alley Build Tool.
+- initial beta publication of Alley Build Tool.

--- a/packages/build-tool/README.md
+++ b/packages/build-tool/README.md
@@ -61,13 +61,16 @@ By default the following command options are applied when running the `build` an
 
 ### Extending the config
 
-Extending the Alley Build Tool webpack configuration is possible and uses the same approach as [extending the webpack config in wp-scripts](https://github.com/WordPress/gutenberg/blob/trunk/packages/scripts/README.md#extending-the-webpack-config) by following the steps below:
+Extending the Alley Build Tool webpack configuration is possible and uses the same approach as [extending the webpack config in wp-scripts](https://github.com/WordPress/gutenberg/blob/trunk/packages/scripts/README.md#extending-the-webpack-config).
+
+There are several ways to extend the webpack configuration. One uses the common JS `require` syntax and the other uses the ESM `import` syntax. The following examples use the common JS `require` syntax.
 * Provide a `webpack.config.js` file in the root of your project.
 * `require` the webpack config from `@alleyinteractive/build-tool` in the `webpack.config.js` file in your project.
 * Use the spread operator to import all of or part of the provided configuration.
 
 ```js
-const defaultConfig = require('@alleyinteractive/build-tool/config/webpack.config');
+const path = require('path');
+const defaultConfig = require('@alleyinteractive/build-tool/dist/cjs/config/webpack.config');
 
 module.exports = {
   ...defaultConfig,
@@ -75,11 +78,17 @@ module.exports = {
   resolve: {
     ...defaultConfig.resolve,
     alias: {
-      ...defaultConfig.resolve.alias,
+      ...defaultConfig.resolve?.alias,
       // Custom alias to resolve paths to the project root. Example: 'root/client/index.js'.
-      'root': path.resolve(__dirname),
+      root: path.resolve(__dirname),
     },
   },
+};
+```
+
+**NOTE**: To use ESM import syntax use the following import path:
+```js
+import defaultConfig from '@alleyinteractive/build-tool/dist/esm/config/webpack.config';
 ```
 ### From Source
 

--- a/packages/build-tool/package.json
+++ b/packages/build-tool/package.json
@@ -62,11 +62,11 @@
     ".": {
       "import": {
         "types": "./dist/esm/types/index.d.ts",
-        "default": "./dist/esm"
+        "default": "./dist/esm/index.mjs"
       },
       "require": {
         "types": "./dist/cjs/types/index.d.ts",
-        "default": "./dist/cjs"
+        "default": "./dist/cjs/index.js"
       }
     },
     "./dist/cjs/config/webpack.config": "./dist/cjs/config/webpack.config.js",

--- a/packages/build-tool/package.json
+++ b/packages/build-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alleyinteractive/build-tool",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An opinionated set of build configurations for wp-scripts",
   "bin": {
     "alley-build": "./dist/cjs/index.js"
@@ -62,12 +62,14 @@
     ".": {
       "import": {
         "types": "./dist/esm/types/index.d.ts",
-        "default": "./dist/esm/index.mjs"
+        "default": "./dist/esm"
       },
       "require": {
         "types": "./dist/cjs/types/index.d.ts",
-        "default": "./dist/cjs/index.js"
+        "default": "./dist/cjs"
       }
-    }
+    },
+    "./dist/cjs/config/webpack.config": "./dist/cjs/config/webpack.config.js",
+    "./dist/esm/config/webpack.config": "./dist/esm/config/webpack.config.js"
   }
 }


### PR DESCRIPTION
This PR solves issue [#458](https://github.com/alleyinteractive/alley-scripts/issues/458) by supplying export paths for CJS and ESM webpack configurations.

The CHANGELOG was also updated with version details for this and the previous release. The order was reorganized to display in reverse chronological order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Released v0.1.2 of `@alleyinteractive/build-tool` with enhanced webpack config exports.
- Introduced `--webpack-blocks-only` option in v0.1.1 for more focused compilation.

Documentation:
- Updated README with instructions on extending webpack config and using new features.

Chores:
- Improved ESLint config and added `prepublishOnly` script for efficient publishing process.
- Adjusted import paths for default configuration to accommodate syntax variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->