### PR TITLE
Fixes alley-create-block compiler to ensure output is NodeJS compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37567,7 +37567,6 @@
         "@wordpress/create-block": "^4.32.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
-        "cross-spawn": "^7.0.3",
         "prompts": "^2.4.2"
       },
       "bin": {
@@ -37577,8 +37576,7 @@
         "@alleyinteractive/eslint-config": "*",
         "@alleyinteractive/tsconfig": "*",
         "@types/command-line-args": "^5.2.3",
-        "@types/command-line-usage": "^5.0.4",
-        "@types/cross-spawn": "^6.0.5"
+        "@types/command-line-usage": "^5.0.4"
       },
       "peerDependencies": {
         "@wordpress/create-block": "*",
@@ -37605,35 +37603,6 @@
         "node": ">=12.20.0"
       }
     },
-    "packages/create-block/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "packages/create-block/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/create-block/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "packages/create-block/node_modules/table-layout": {
       "version": "3.0.2",
       "license": "MIT",
@@ -37658,19 +37627,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
-      }
-    },
-    "packages/create-block/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "packages/create-block/node_modules/wordwrapjs": {
@@ -38201,11 +38157,9 @@
         "@alleyinteractive/tsconfig": "*",
         "@types/command-line-args": "^5.2.3",
         "@types/command-line-usage": "^5.0.4",
-        "@types/cross-spawn": "^6.0.5",
         "@wordpress/create-block": "^4.32.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
-        "cross-spawn": "^7.0.3",
         "prompts": "^2.4.2"
       },
       "dependencies": {
@@ -38221,23 +38175,6 @@
             "typical": "^7.1.1"
           }
         },
-        "cross-spawn": {
-          "version": "7.0.3",
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0"
-        },
         "table-layout": {
           "version": "3.0.2",
           "requires": {
@@ -38252,12 +38189,6 @@
         },
         "typical": {
           "version": "7.1.1"
-        },
-        "which": {
-          "version": "2.0.2",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
         },
         "wordwrapjs": {
           "version": "5.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13113,6 +13113,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "dev": true
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "dev": true
+    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "license": "MIT",
@@ -15446,10 +15458,11 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/create-block": {
-      "version": "4.26.0",
-      "license": "GPL-2.0-or-later",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.32.0.tgz",
+      "integrity": "sha512-4WR0meMqIZJEi954fU/bTuN+a9FIwx25wsv2r4uq60RpgYqD2oux39N+TkqpauC/PH2s3eMB6IWpv93C3RaGng==",
       "dependencies": {
-        "@wordpress/lazy-import": "^1.29.0",
+        "@wordpress/lazy-import": "^1.35.0",
         "chalk": "^4.0.0",
         "change-case": "^4.1.2",
         "check-node-version": "^4.1.0",
@@ -16914,8 +16927,9 @@
       }
     },
     "node_modules/@wordpress/lazy-import": {
-      "version": "1.29.0",
-      "license": "GPL-2.0-or-later",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/lazy-import/-/lazy-import-1.35.0.tgz",
+      "integrity": "sha512-MKWmXkIvjCa9RLKaZqgipUuLOxvpqkBw+0fWAR2iZdFdRJJR2eQSWbyYCkYxQPIxdH5A3KMjgaweAv22pZlCLg==",
       "dependencies": {
         "execa": "^4.0.2",
         "npm-package-arg": "^8.1.5",
@@ -16927,7 +16941,8 @@
     },
     "node_modules/@wordpress/lazy-import/node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -16937,7 +16952,8 @@
     },
     "node_modules/@wordpress/lazy-import/node_modules/semver": {
       "version": "7.5.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -16950,7 +16966,8 @@
     },
     "node_modules/@wordpress/lazy-import/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@wordpress/list-reusable-blocks": {
       "version": "4.22.0",
@@ -19959,7 +19976,8 @@
     },
     "node_modules/builtins": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ=="
     },
     "node_modules/bundle-name": {
       "version": "3.0.0",
@@ -23910,7 +23928,8 @@
     },
     "node_modules/execa": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -23931,7 +23950,8 @@
     },
     "node_modules/execa/node_modules/cross-spawn": {
       "version": "7.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -23943,7 +23963,8 @@
     },
     "node_modules/execa/node_modules/shebang-command": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -23953,14 +23974,16 @@
     },
     "node_modules/execa/node_modules/shebang-regex": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/execa/node_modules/which": {
       "version": "2.0.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -25529,7 +25552,8 @@
     },
     "node_modules/human-signals": {
       "version": "1.1.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "engines": {
         "node": ">=8.12.0"
       }
@@ -29845,7 +29869,8 @@
     },
     "node_modules/npm-package-arg": {
       "version": "8.1.5",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
       "dependencies": {
         "hosted-git-info": "^4.0.1",
         "semver": "^7.3.4",
@@ -29857,7 +29882,8 @@
     },
     "node_modules/npm-package-arg/node_modules/hosted-git-info": {
       "version": "4.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -29867,7 +29893,8 @@
     },
     "node_modules/npm-package-arg/node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -29877,7 +29904,8 @@
     },
     "node_modules/npm-package-arg/node_modules/semver": {
       "version": "7.5.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -29890,7 +29918,8 @@
     },
     "node_modules/npm-package-arg/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/npm-package-json-lint": {
       "version": "6.4.0",
@@ -36156,7 +36185,8 @@
     },
     "node_modules/validate-npm-package-name": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
       "dependencies": {
         "builtins": "^1.0.3"
       }
@@ -37369,7 +37399,7 @@
     },
     "packages/block-editor-tools": {
       "name": "@alleyinteractive/block-editor-tools",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@alleyinteractive/eslint-config": "*",
@@ -37411,7 +37441,7 @@
       },
       "engines": {
         "node": ">=16.0.0",
-        "npm": ">=8"
+        "npm": ">=8.0.0"
       },
       "peerDependencies": {
         "react": ">=18"
@@ -37534,6 +37564,7 @@
       "version": "0.1.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
+        "@wordpress/create-block": "^4.32.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
         "cross-spawn": "^7.0.3",
@@ -37545,10 +37576,12 @@
       "devDependencies": {
         "@alleyinteractive/eslint-config": "*",
         "@alleyinteractive/tsconfig": "*",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
         "@types/cross-spawn": "^6.0.5"
       },
       "peerDependencies": {
-        "@wordpress/create-block": "^4.26.0",
+        "@wordpress/create-block": "*",
         "@wordpress/scripts": "*"
       }
     },
@@ -38166,7 +38199,10 @@
       "requires": {
         "@alleyinteractive/eslint-config": "*",
         "@alleyinteractive/tsconfig": "*",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
         "@types/cross-spawn": "^6.0.5",
+        "@wordpress/create-block": "^4.32.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
         "cross-spawn": "^7.0.3",
@@ -46633,6 +46669,18 @@
         "@types/node": "*"
       }
     },
+    "@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "dev": true
+    },
+    "@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "dev": true
+    },
     "@types/connect": {
       "version": "3.4.35",
       "requires": {
@@ -48398,9 +48446,11 @@
       }
     },
     "@wordpress/create-block": {
-      "version": "4.26.0",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.32.0.tgz",
+      "integrity": "sha512-4WR0meMqIZJEi954fU/bTuN+a9FIwx25wsv2r4uq60RpgYqD2oux39N+TkqpauC/PH2s3eMB6IWpv93C3RaGng==",
       "requires": {
-        "@wordpress/lazy-import": "^1.29.0",
+        "@wordpress/lazy-import": "^1.35.0",
         "chalk": "^4.0.0",
         "change-case": "^4.1.2",
         "check-node-version": "^4.1.0",
@@ -49498,7 +49548,9 @@
       }
     },
     "@wordpress/lazy-import": {
-      "version": "1.29.0",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/lazy-import/-/lazy-import-1.35.0.tgz",
+      "integrity": "sha512-MKWmXkIvjCa9RLKaZqgipUuLOxvpqkBw+0fWAR2iZdFdRJJR2eQSWbyYCkYxQPIxdH5A3KMjgaweAv22pZlCLg==",
       "requires": {
         "execa": "^4.0.2",
         "npm-package-arg": "^8.1.5",
@@ -49507,18 +49559,24 @@
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -51612,7 +51670,9 @@
       "version": "3.3.0"
     },
     "builtins": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ=="
     },
     "bundle-name": {
       "version": "3.0.0",
@@ -53967,6 +54027,8 @@
     },
     "execa": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
       "requires": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -53981,6 +54043,8 @@
       "dependencies": {
         "cross-spawn": {
           "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -53989,15 +54053,21 @@
         },
         "shebang-command": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "requires": {
             "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "which": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -54974,7 +55044,9 @@
       "dev": true
     },
     "human-signals": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -57524,6 +57596,8 @@
     },
     "npm-package-arg": {
       "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
       "requires": {
         "hosted-git-info": "^4.0.1",
         "semver": "^7.3.4",
@@ -57532,24 +57606,32 @@
       "dependencies": {
         "hosted-git-info": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -61297,6 +61379,8 @@
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
       "requires": {
         "builtins": "^1.0.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37561,7 +37561,7 @@
     },
     "packages/create-block": {
       "name": "@alleyinteractive/create-block",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/create-block": "^4.32.0",

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.2 - 2023-12-15
 
-- Bug fix error where an import statement is used outside of a module. Ensures built files are compatible with CommonJS.
+- Bug fix error where an import statement is used outside of a module. Ensures built files are compatible with NodeJS.
 
 ## 0.1.1 - 2023-11-20
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 - 2023-12-15
+
+- Bug fix error where an import statement is used outside of a module. Ensures built files are compatible with CommonJS.
+
 ## 0.1.1 - 2023-11-20
 
 - Remove `"module": "node16"` from `tsconfig.json` to inherit the default value of `"module": "esnext"`.

--- a/packages/create-block/index.ts
+++ b/packages/create-block/index.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
 import { chdir, cwd } from 'node:process';
+import { spawn } from 'node:child_process';
 
 /* eslint-disable no-console */
-const fs = require('fs');
-const prompts = require('prompts');
-const path = require('path');
-const spawn = require('cross-spawn');
-const commandLineArgs = require('command-line-args');
-const commandLineUsage = require('command-line-usage');
+import fs from 'fs';
+import prompts from 'prompts';
+import path from 'path';
+import commandLineArgs, { OptionDefinition } from 'command-line-args';
+import commandLineUsage from 'command-line-usage';
 
 type Options = {
   name: string;
@@ -76,12 +76,7 @@ const {
   blocksDir: blocksDirectory,
   blockLanguage,
   help,
-} : {
-  namespace: string;
-  blocksDir: string;
-  blockLanguage: LanguageType | undefined;
-  help: boolean;
-} = commandLineArgs(options);
+} = commandLineArgs(options as OptionDefinition[]);
 
 // Display the help text if the --help option is used.
 const usage = commandLineUsage([
@@ -91,7 +86,7 @@ const usage = commandLineUsage([
   },
   {
     header: 'Options',
-    optionList: options,
+    optionList: options as OptionDefinition[],
   },
 ]);
 
@@ -148,7 +143,7 @@ if (help) {
   }
 
   // Create a block using the @wordpress/create-block package.
-  spawn.sync(
+  spawn(
     'wp-create-block',
     [
       /**

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alleyinteractive/create-block",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Alley's custom block scaffolding variation for the @wordpress/create-block script.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -2,12 +2,14 @@
   "name": "@alleyinteractive/create-block",
   "version": "0.1.1",
   "description": "Alley's custom block scaffolding variation for the @wordpress/create-block script.",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "clean": "rm -rf dist",
     "watch": "tsc -w",
     "lint": "eslint index.ts src",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "prebuild": "npm run clean"
   },
   "repository": {
     "type": "git",
@@ -17,7 +19,7 @@
     "alley-create-block": "./dist/index.js"
   },
   "peerDependencies": {
-    "@wordpress/create-block": "^4.26.0",
+    "@wordpress/create-block": "*",
     "@wordpress/scripts": "*"
   },
   "keywords": [
@@ -33,6 +35,7 @@
   },
   "homepage": "https://github.com/alleyinteractive/alley-scripts/tree/main/packages/create-block",
   "dependencies": {
+    "@wordpress/create-block": "^4.32.0",
     "command-line-args": "^5.2.1",
     "command-line-usage": "^7.0.1",
     "cross-spawn": "^7.0.3",
@@ -41,6 +44,8 @@
   "devDependencies": {
     "@alleyinteractive/eslint-config": "*",
     "@alleyinteractive/tsconfig": "*",
+    "@types/command-line-args": "^5.2.3",
+    "@types/command-line-usage": "^5.0.4",
     "@types/cross-spawn": "^6.0.5"
   },
   "files": [

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -35,18 +35,16 @@
   },
   "homepage": "https://github.com/alleyinteractive/alley-scripts/tree/main/packages/create-block",
   "dependencies": {
-    "@wordpress/create-block": "^4.32.0",
+    "@wordpress/create-block": "*",
     "command-line-args": "^5.2.1",
     "command-line-usage": "^7.0.1",
-    "cross-spawn": "^7.0.3",
     "prompts": "^2.4.2"
   },
   "devDependencies": {
     "@alleyinteractive/eslint-config": "*",
     "@alleyinteractive/tsconfig": "*",
     "@types/command-line-args": "^5.2.3",
-    "@types/command-line-usage": "^5.0.4",
-    "@types/cross-spawn": "^6.0.5"
+    "@types/command-line-usage": "^5.0.4"
   },
   "files": [
     "dist",

--- a/packages/create-block/tsconfig.json
+++ b/packages/create-block/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@alleyinteractive/tsconfig/base.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "module": "nodeNext",
     "moduleResolution": "nodenext",

--- a/packages/create-block/tsconfig.json
+++ b/packages/create-block/tsconfig.json
@@ -3,11 +3,9 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
-    "lib": ["ES2022"],
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "nodeNext",
+    "moduleResolution": "nodenext",
     "outDir": "dist",
-    "target": "ES2022",
   },
   "exclude": [
     "dist",

--- a/packages/create-block/tsconfig.json
+++ b/packages/create-block/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "extends": "@alleyinteractive/tsconfig/base.json",
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
+    "lib": ["ES2022"],
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "outDir": "dist",
+    "target": "ES2022",
   },
   "exclude": [
     "dist",


### PR DESCRIPTION
### Summary
Fixes #511 where the `alley-create-block` script is throwing an error about using an import statement outside of a module. 

This PR addresses this by ensuring that the Typescript compiler `module` and `moduleResolution` are set to NodeJS and Node. I believe the issue was introduced in 66dfdec from PR #480 where the `module` config rule was removed from the package `tsconfig.json` file.

This change adds the module config value back and changes the value to `nodenext` for modern versions of Node.js. The corresponding `moduleResolution` value was also added and when combined with the [module](https://www.typescriptlang.org/tsconfig#module) values, the TypeScript compiler will pick the right algorithm for each resolution based on whether Node.js will see an import or require in the output JavaScript code.
-- source https://www.typescriptlang.org/tsconfig#moduleResolution

**Additional Changes include:**
* Removing `cross-spawn` as a dependency in favor of Nodes native spawn
* Remove mixing of import and require in the index file and address TS warnings.
* Adds a `clean` script that will remove the dist directory before building.
