### PR TITLE
Issue-499: block editor tools components, hooks, and services have incomplete documentation

### DIFF
--- a/.changeset/chilly-hounds-repair.md
+++ b/.changeset/chilly-hounds-repair.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/block-editor-tools": patch
+---
+
+Updated README that documents components, hooks, and services usage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12885,35 +12885,6 @@
       "version": "1.1.0",
       "license": "MIT"
     },
-    "node_modules/@tanstack/react-table": {
-      "version": "8.10.7",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/table-core": "8.10.7"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@tanstack/table-core": {
-      "version": "8.10.7",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
     "node_modules/@testing-library/dom": {
       "version": "9.3.1",
       "license": "MIT",
@@ -13497,6 +13468,7 @@
     },
     "node_modules/@types/stylis": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tapable": {
@@ -14511,25 +14483,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/annotations": {
-      "version": "2.45.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/rich-text": "^6.22.0",
-        "rememo": "^4.0.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
     "node_modules/@wordpress/api-fetch": {
       "version": "6.42.0",
       "license": "GPL-2.0-or-later",
@@ -14596,163 +14549,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@wordpress/block-directory": {
-      "version": "4.22.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/api-fetch": "^6.42.0",
-        "@wordpress/block-editor": "^12.13.0",
-        "@wordpress/blocks": "^12.22.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/core-data": "^6.22.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/edit-post": "^7.22.0",
-        "@wordpress/editor": "^13.22.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/notices": "^4.13.0",
-        "@wordpress/plugins": "^6.13.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/url": "^3.46.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-directory/node_modules/@wordpress/components": {
-      "version": "25.11.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.5",
-        "@ariakit/test": "^0.3.0",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.1",
-        "@radix-ui/react-dropdown-menu": "2.0.4",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.2.24",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/date": "^4.45.0",
-        "@wordpress/deprecated": "^3.45.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/escape-html": "^2.45.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/primitives": "^3.43.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/rich-text": "^6.22.0",
-        "@wordpress/warning": "^2.45.0",
-        "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
-        "colord": "^2.7.0",
-        "date-fns": "^2.28.0",
-        "deepmerge": "^4.3.0",
-        "dom-scroll-into-view": "^1.2.1",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^10.13.0",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "reakit": "^1.3.11",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.1",
-        "uuid": "^9.0.1",
-        "valtio": "1.7.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-directory/node_modules/@wordpress/notices": {
-      "version": "4.13.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/data": "^9.15.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-directory/node_modules/@wordpress/plugins": {
-      "version": "6.13.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "memize": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-directory/node_modules/@wordpress/private-apis": {
-      "version": "0.27.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/block-directory/node_modules/memize": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/block-directory/node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/block-directory/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "license": "MIT"
     },
     "node_modules/@wordpress/block-editor": {
       "version": "12.13.0",
@@ -15569,129 +15365,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@wordpress/customize-widgets": {
-      "version": "4.22.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/block-editor": "^12.13.0",
-        "@wordpress/block-library": "^8.22.0",
-        "@wordpress/blocks": "^12.22.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/core-data": "^6.22.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/interface": "^5.22.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "@wordpress/keyboard-shortcuts": "^4.22.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/media-utils": "^4.36.0",
-        "@wordpress/preferences": "^3.22.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/widgets": "^3.22.0",
-        "classnames": "^2.3.1",
-        "fast-deep-equal": "^3.1.3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/customize-widgets/node_modules/@wordpress/components": {
-      "version": "25.11.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.5",
-        "@ariakit/test": "^0.3.0",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.1",
-        "@radix-ui/react-dropdown-menu": "2.0.4",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.2.24",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/date": "^4.45.0",
-        "@wordpress/deprecated": "^3.45.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/escape-html": "^2.45.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/primitives": "^3.43.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/rich-text": "^6.22.0",
-        "@wordpress/warning": "^2.45.0",
-        "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
-        "colord": "^2.7.0",
-        "date-fns": "^2.28.0",
-        "deepmerge": "^4.3.0",
-        "dom-scroll-into-view": "^1.2.1",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^10.13.0",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "reakit": "^1.3.11",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.1",
-        "uuid": "^9.0.1",
-        "valtio": "1.7.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/customize-widgets/node_modules/@wordpress/private-apis": {
-      "version": "0.27.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/customize-widgets/node_modules/memize": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/customize-widgets/node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/customize-widgets/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/data": {
       "version": "9.15.0",
       "license": "GPL-2.0-or-later",
@@ -15717,19 +15390,6 @@
       },
       "peerDependencies": {
         "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/data-controls": {
-      "version": "2.30.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/api-fetch": "^6.27.0",
-        "@wordpress/data": "^9.0.0",
-        "@wordpress/deprecated": "^3.30.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@wordpress/data/node_modules/@wordpress/private-apis": {
@@ -16013,357 +15673,6 @@
       "version": "0.5.0",
       "license": "MIT"
     },
-    "node_modules/@wordpress/edit-site": {
-      "version": "5.22.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@tanstack/react-table": "^8.10.3",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/api-fetch": "^6.42.0",
-        "@wordpress/block-editor": "^12.13.0",
-        "@wordpress/block-library": "^8.22.0",
-        "@wordpress/blocks": "^12.22.0",
-        "@wordpress/commands": "^0.16.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/core-commands": "^0.14.0",
-        "@wordpress/core-data": "^6.22.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/date": "^4.45.0",
-        "@wordpress/deprecated": "^3.45.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/editor": "^13.22.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/escape-html": "^2.45.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/interface": "^5.22.0",
-        "@wordpress/keyboard-shortcuts": "^4.22.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/media-utils": "^4.36.0",
-        "@wordpress/notices": "^4.13.0",
-        "@wordpress/patterns": "^1.6.0",
-        "@wordpress/plugins": "^6.13.0",
-        "@wordpress/preferences": "^3.22.0",
-        "@wordpress/primitives": "^3.43.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/reusable-blocks": "^4.22.0",
-        "@wordpress/router": "^0.14.0",
-        "@wordpress/style-engine": "^1.28.0",
-        "@wordpress/url": "^3.46.0",
-        "@wordpress/viewport": "^5.22.0",
-        "@wordpress/widgets": "^3.22.0",
-        "@wordpress/wordcount": "^3.45.0",
-        "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
-        "colord": "^2.9.2",
-        "deepmerge": "^4.3.0",
-        "downloadjs": "^1.4.7",
-        "fast-deep-equal": "^3.1.3",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "react-autosize-textarea": "^7.1.0",
-        "rememo": "^4.0.2",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/edit-site/node_modules/@wordpress/components": {
-      "version": "25.11.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.5",
-        "@ariakit/test": "^0.3.0",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.1",
-        "@radix-ui/react-dropdown-menu": "2.0.4",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.2.24",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/date": "^4.45.0",
-        "@wordpress/deprecated": "^3.45.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/escape-html": "^2.45.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/primitives": "^3.43.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/rich-text": "^6.22.0",
-        "@wordpress/warning": "^2.45.0",
-        "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
-        "colord": "^2.7.0",
-        "date-fns": "^2.28.0",
-        "deepmerge": "^4.3.0",
-        "dom-scroll-into-view": "^1.2.1",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^10.13.0",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "reakit": "^1.3.11",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.1",
-        "uuid": "^9.0.1",
-        "valtio": "1.7.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/edit-site/node_modules/@wordpress/notices": {
-      "version": "4.13.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/data": "^9.15.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/edit-site/node_modules/@wordpress/plugins": {
-      "version": "6.13.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "memize": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/edit-site/node_modules/@wordpress/private-apis": {
-      "version": "0.27.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/edit-site/node_modules/memize": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/edit-site/node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/edit-site/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/edit-widgets": {
-      "version": "5.22.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/api-fetch": "^6.42.0",
-        "@wordpress/block-editor": "^12.13.0",
-        "@wordpress/block-library": "^8.22.0",
-        "@wordpress/blocks": "^12.22.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/core-data": "^6.22.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/deprecated": "^3.45.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/interface": "^5.22.0",
-        "@wordpress/keyboard-shortcuts": "^4.22.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/media-utils": "^4.36.0",
-        "@wordpress/notices": "^4.13.0",
-        "@wordpress/patterns": "^1.6.0",
-        "@wordpress/plugins": "^6.13.0",
-        "@wordpress/preferences": "^3.22.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/reusable-blocks": "^4.22.0",
-        "@wordpress/url": "^3.46.0",
-        "@wordpress/widgets": "^3.22.0",
-        "classnames": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/edit-widgets/node_modules/@wordpress/components": {
-      "version": "25.11.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.5",
-        "@ariakit/test": "^0.3.0",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.1",
-        "@radix-ui/react-dropdown-menu": "2.0.4",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.2.24",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/date": "^4.45.0",
-        "@wordpress/deprecated": "^3.45.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/escape-html": "^2.45.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/primitives": "^3.43.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/rich-text": "^6.22.0",
-        "@wordpress/warning": "^2.45.0",
-        "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
-        "colord": "^2.7.0",
-        "date-fns": "^2.28.0",
-        "deepmerge": "^4.3.0",
-        "dom-scroll-into-view": "^1.2.1",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^10.13.0",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "reakit": "^1.3.11",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.1",
-        "uuid": "^9.0.1",
-        "valtio": "1.7.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/edit-widgets/node_modules/@wordpress/notices": {
-      "version": "4.13.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/data": "^9.15.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/edit-widgets/node_modules/@wordpress/plugins": {
-      "version": "6.13.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "memize": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/edit-widgets/node_modules/@wordpress/private-apis": {
-      "version": "0.27.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/edit-widgets/node_modules/memize": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/edit-widgets/node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/edit-widgets/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/editor": {
       "version": "13.22.0",
       "license": "GPL-2.0-or-later",
@@ -16541,118 +15850,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@wordpress/format-library": {
-      "version": "4.22.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/block-editor": "^12.13.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/rich-text": "^6.22.0",
-        "@wordpress/url": "^3.46.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/format-library/node_modules/@wordpress/components": {
-      "version": "25.11.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.5",
-        "@ariakit/test": "^0.3.0",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.1",
-        "@radix-ui/react-dropdown-menu": "2.0.4",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.2.24",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/date": "^4.45.0",
-        "@wordpress/deprecated": "^3.45.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/escape-html": "^2.45.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/primitives": "^3.43.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/rich-text": "^6.22.0",
-        "@wordpress/warning": "^2.45.0",
-        "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
-        "colord": "^2.7.0",
-        "date-fns": "^2.28.0",
-        "deepmerge": "^4.3.0",
-        "dom-scroll-into-view": "^1.2.1",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^10.13.0",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "reakit": "^1.3.11",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.1",
-        "uuid": "^9.0.1",
-        "valtio": "1.7.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/format-library/node_modules/@wordpress/private-apis": {
-      "version": "0.27.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/format-library/node_modules/memize": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/format-library/node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/format-library/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "license": "MIT"
     },
     "node_modules/@wordpress/hooks": {
       "version": "3.45.0",
@@ -16969,113 +16166,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
-    "node_modules/@wordpress/list-reusable-blocks": {
-      "version": "4.22.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/api-fetch": "^6.42.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/i18n": "^4.45.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/list-reusable-blocks/node_modules/@wordpress/components": {
-      "version": "25.11.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.5",
-        "@ariakit/test": "^0.3.0",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.1",
-        "@radix-ui/react-dropdown-menu": "2.0.4",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.2.24",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/date": "^4.45.0",
-        "@wordpress/deprecated": "^3.45.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/escape-html": "^2.45.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/primitives": "^3.43.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/rich-text": "^6.22.0",
-        "@wordpress/warning": "^2.45.0",
-        "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
-        "colord": "^2.7.0",
-        "date-fns": "^2.28.0",
-        "deepmerge": "^4.3.0",
-        "dom-scroll-into-view": "^1.2.1",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^10.13.0",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "reakit": "^1.3.11",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.1",
-        "uuid": "^9.0.1",
-        "valtio": "1.7.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/list-reusable-blocks/node_modules/@wordpress/private-apis": {
-      "version": "0.27.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/list-reusable-blocks/node_modules/memize": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/list-reusable-blocks/node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/list-reusable-blocks/node_modules/remove-accents": {
-      "version": "0.5.0",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/media-utils": {
       "version": "4.36.0",
       "license": "GPL-2.0-or-later",
@@ -17090,18 +16180,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/notices": {
-      "version": "3.31.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.31.0",
-        "@wordpress/data": "^9.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@wordpress/npm-package-json-lint-config": {
       "version": "4.30.0",
       "license": "GPL-2.0-or-later",
@@ -17110,55 +16188,6 @@
       },
       "peerDependencies": {
         "npm-package-json-lint": ">=6.0.0"
-      }
-    },
-    "node_modules/@wordpress/nux": {
-      "version": "6.0.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/components": "^23.0.0",
-        "@wordpress/compose": "^6.0.0",
-        "@wordpress/data": "^8.0.0",
-        "@wordpress/deprecated": "^3.23.0",
-        "@wordpress/element": "^5.0.0",
-        "@wordpress/i18n": "^4.23.0",
-        "@wordpress/icons": "^9.14.0",
-        "rememo": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/nux/node_modules/@wordpress/data": {
-      "version": "8.6.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.6.0",
-        "@wordpress/deprecated": "^3.29.0",
-        "@wordpress/element": "^5.6.0",
-        "@wordpress/is-shallow-equal": "^4.29.0",
-        "@wordpress/priority-queue": "^2.29.0",
-        "@wordpress/private-apis": "^0.11.0",
-        "@wordpress/redux-routine": "^4.29.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "turbo-combine-reducers": "^1.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/patterns": {
@@ -20049,6 +19078,7 @@
     },
     "node_modules/camelize": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -21088,6 +20118,7 @@
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4"
@@ -21177,6 +20208,7 @@
     },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.0",
@@ -22307,10 +21339,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/downloadjs": {
-      "version": "1.4.7",
-      "license": "MIT"
     },
     "node_modules/downshift": {
       "version": "6.1.12",
@@ -30669,6 +29697,7 @@
     },
     "node_modules/papaparse": {
       "version": "5.4.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/param-case": {
@@ -33279,6 +32308,7 @@
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/shebang-command": {
@@ -34221,6 +33251,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.1.tgz",
       "integrity": "sha512-cpZZP5RrKRIClBW5Eby4JM1wElLVP4NQrJbJ0h10TidTyJf4SIIwa3zLXOoPb4gJi8MsJ8mjq5mu2IrEhZIAcQ==",
+      "dev": true,
       "dependencies": {
         "@emotion/is-prop-valid": "^1.2.1",
         "@emotion/unitless": "^0.8.0",
@@ -34246,6 +33277,7 @@
     },
     "node_modules/styled-components/node_modules/stylis": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stylehacks": {
@@ -35143,13 +34175,6 @@
       "version": "0.0.3",
       "license": "MIT"
     },
-    "node_modules/traverse": {
-      "version": "0.6.7",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "license": "MIT",
@@ -35347,6 +34372,7 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
       "integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.0.0",
@@ -35364,6 +34390,7 @@
     },
     "node_modules/ts-loader/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -35377,6 +34404,7 @@
     },
     "node_modules/ts-loader/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -35391,6 +34419,7 @@
     },
     "node_modules/ts-loader/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -35401,10 +34430,12 @@
     },
     "node_modules/ts-loader/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-loader/node_modules/enhanced-resolve": {
       "version": "5.12.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -35416,6 +34447,7 @@
     },
     "node_modules/ts-loader/node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -35423,6 +34455,7 @@
     },
     "node_modules/ts-loader/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -35433,6 +34466,7 @@
     },
     "node_modules/ts-loader/node_modules/semver": {
       "version": "7.5.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -35448,12 +34482,14 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/ts-loader/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -35464,6 +34500,7 @@
     },
     "node_modules/ts-loader/node_modules/tapable": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -35471,6 +34508,7 @@
     },
     "node_modules/ts-loader/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ts-node": {
@@ -37012,6 +36050,7 @@
       "version": "3.64.0",
       "resolved": "https://registry.npmjs.org/wp-types/-/wp-types-3.64.0.tgz",
       "integrity": "sha512-8rwHUQFxI18jezvObymV0eKEhnU2xaSci5ra6YG+dV6EDZLfNR2z3NZA82mFkOzZRWpl/Dlj+a4u8aqk08UPGQ==",
+      "dev": true,
       "dependencies": {
         "typescript": ">=3"
       },
@@ -37399,7 +36438,7 @@
     },
     "packages/block-editor-tools": {
       "name": "@alleyinteractive/block-editor-tools",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@alleyinteractive/eslint-config": "*",
@@ -37814,148 +36853,6 @@
       "engines": {
         "node": ">=16.0.0 <21.0.0",
         "npm": ">=8"
-      }
-    },
-    "plugin/node_modules/@alleyinteractive/block-editor-tools": {
-      "version": "0.3.8",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@alleyinteractive/tsconfig": "*",
-        "@wordpress/a11y": "^3.30.0",
-        "@wordpress/annotations": "^2.30.0",
-        "@wordpress/api-fetch": "^6.27.0",
-        "@wordpress/autop": "^3.30.0",
-        "@wordpress/blob": "^3.30.0",
-        "@wordpress/block-directory": "^4.7.0",
-        "@wordpress/block-editor": "^11.7.0",
-        "@wordpress/block-library": "^8.7.0",
-        "@wordpress/block-serialization-default-parser": "^4.30.0",
-        "@wordpress/blocks": "^12.7.0",
-        "@wordpress/components": "^23.7.0",
-        "@wordpress/compose": "^6.7.0",
-        "@wordpress/core-data": "^6.7.0",
-        "@wordpress/create-block": "^4.14.0",
-        "@wordpress/customize-widgets": "^4.7.0",
-        "@wordpress/data": "^9.0.0",
-        "@wordpress/data-controls": "^2.30.0",
-        "@wordpress/date": "^4.30.0",
-        "@wordpress/deprecated": "^3.30.0",
-        "@wordpress/dom": "^3.30.0",
-        "@wordpress/dom-ready": "^3.30.0",
-        "@wordpress/edit-post": "^7.7.0",
-        "@wordpress/edit-site": "^5.7.0",
-        "@wordpress/edit-widgets": "^5.7.0",
-        "@wordpress/element": "^5.7.0",
-        "@wordpress/escape-html": "^2.30.0",
-        "@wordpress/format-library": "^4.7.0",
-        "@wordpress/hooks": "^3.30.0",
-        "@wordpress/html-entities": "^3.30.0",
-        "@wordpress/i18n": "^4.30.0",
-        "@wordpress/icons": "^9.21.0",
-        "@wordpress/interface": "^5.7.0",
-        "@wordpress/is-shallow-equal": "^4.30.0",
-        "@wordpress/keyboard-shortcuts": "^4.7.0",
-        "@wordpress/keycodes": "^3.30.0",
-        "@wordpress/list-reusable-blocks": "^4.7.0",
-        "@wordpress/media-utils": "^4.21.0",
-        "@wordpress/notices": "^3.30.0",
-        "@wordpress/nux": "^6.0.0",
-        "@wordpress/plugins": "^5.7.0",
-        "@wordpress/primitives": "^3.28.0",
-        "@wordpress/priority-queue": "^2.30.0",
-        "@wordpress/redux-routine": "^4.30.0",
-        "@wordpress/reusable-blocks": "^4.7.0",
-        "@wordpress/rich-text": "^6.7.0",
-        "@wordpress/scripts": "^26.1.0",
-        "@wordpress/server-side-render": "^4.7.0",
-        "@wordpress/shortcode": "^3.30.0",
-        "@wordpress/token-list": "^2.30.0",
-        "@wordpress/url": "^3.31.0",
-        "@wordpress/viewport": "^5.7.0",
-        "@wordpress/warning": "^2.30.0",
-        "@wordpress/widgets": "^3.7.0",
-        "@wordpress/wordcount": "^3.30.0",
-        "classnames": "^2.3.2",
-        "dompurify": "^3.0.6",
-        "lodash": "^4.17.21",
-        "papaparse": "^5.4.0",
-        "prop-types": "^15.8.1",
-        "react": "18.2.0",
-        "styled-components": "^6.1.0",
-        "ts-loader": "^9.4.4",
-        "uuid": "^9.0.1",
-        "wp-types": "^3.62.4"
-      },
-      "engines": {
-        "node": ">=16.0.0 <19.0.0",
-        "npm": ">=8.0.0 <10.0.0"
-      }
-    },
-    "plugin/node_modules/@wordpress/block-editor": {
-      "version": "11.8.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^3.31.0",
-        "@wordpress/api-fetch": "^6.28.0",
-        "@wordpress/blob": "^3.31.0",
-        "@wordpress/blocks": "^12.8.0",
-        "@wordpress/components": "^23.8.0",
-        "@wordpress/compose": "^6.8.0",
-        "@wordpress/data": "^9.1.0",
-        "@wordpress/date": "^4.31.0",
-        "@wordpress/deprecated": "^3.31.0",
-        "@wordpress/dom": "^3.31.0",
-        "@wordpress/element": "^5.8.0",
-        "@wordpress/escape-html": "^2.31.0",
-        "@wordpress/hooks": "^3.31.0",
-        "@wordpress/html-entities": "^3.31.0",
-        "@wordpress/i18n": "^4.31.0",
-        "@wordpress/icons": "^9.22.0",
-        "@wordpress/is-shallow-equal": "^4.31.0",
-        "@wordpress/keyboard-shortcuts": "^4.8.0",
-        "@wordpress/keycodes": "^3.31.0",
-        "@wordpress/notices": "^3.31.0",
-        "@wordpress/preferences": "^3.8.0",
-        "@wordpress/private-apis": "^0.13.0",
-        "@wordpress/rich-text": "^6.8.0",
-        "@wordpress/shortcode": "^3.31.0",
-        "@wordpress/style-engine": "^1.14.0",
-        "@wordpress/token-list": "^2.31.0",
-        "@wordpress/url": "^3.32.0",
-        "@wordpress/warning": "^2.31.0",
-        "@wordpress/wordcount": "^3.31.0",
-        "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
-        "colord": "^2.7.0",
-        "diff": "^4.0.2",
-        "dom-scroll-into-view": "^1.2.1",
-        "fast-deep-equal": "^3.1.3",
-        "inherits": "^2.0.3",
-        "lodash": "^4.17.21",
-        "react-autosize-textarea": "^7.1.0",
-        "react-easy-crop": "^4.5.1",
-        "rememo": "^4.0.0",
-        "remove-accents": "^0.4.2",
-        "traverse": "^0.6.6"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "plugin/node_modules/@wordpress/private-apis": {
-      "version": "0.13.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "plugin/node_modules/cross-spawn": {
@@ -46457,15 +45354,6 @@
     "@tannin/postfix": {
       "version": "1.1.0"
     },
-    "@tanstack/react-table": {
-      "version": "8.10.7",
-      "requires": {
-        "@tanstack/table-core": "8.10.7"
-      }
-    },
-    "@tanstack/table-core": {
-      "version": "8.10.7"
-    },
     "@testing-library/dom": {
       "version": "9.3.1",
       "requires": {
@@ -46929,7 +45817,8 @@
       }
     },
     "@types/stylis": {
-      "version": "4.2.0"
+      "version": "4.2.0",
+      "dev": true
     },
     "@types/tapable": {
       "version": "1.0.12",
@@ -47640,18 +46529,6 @@
         "@wordpress/i18n": "^4.45.0"
       }
     },
-    "@wordpress/annotations": {
-      "version": "2.45.0",
-      "requires": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/rich-text": "^6.22.0",
-        "rememo": "^4.0.2",
-        "uuid": "^9.0.1"
-      }
-    },
     "@wordpress/api-fetch": {
       "version": "6.42.0",
       "requires": {
@@ -47694,127 +46571,6 @@
       "version": "3.45.0",
       "requires": {
         "@babel/runtime": "^7.16.0"
-      }
-    },
-    "@wordpress/block-directory": {
-      "version": "4.22.0",
-      "requires": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/api-fetch": "^6.42.0",
-        "@wordpress/block-editor": "^12.13.0",
-        "@wordpress/blocks": "^12.22.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/core-data": "^6.22.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/edit-post": "^7.22.0",
-        "@wordpress/editor": "^13.22.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/notices": "^4.13.0",
-        "@wordpress/plugins": "^6.13.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/url": "^3.46.0",
-        "change-case": "^4.1.2"
-      },
-      "dependencies": {
-        "@wordpress/components": {
-          "version": "25.11.0",
-          "requires": {
-            "@ariakit/react": "^0.3.5",
-            "@ariakit/test": "^0.3.0",
-            "@babel/runtime": "^7.16.0",
-            "@emotion/cache": "^11.7.1",
-            "@emotion/css": "^11.7.1",
-            "@emotion/react": "^11.7.1",
-            "@emotion/serialize": "^1.0.2",
-            "@emotion/styled": "^11.6.0",
-            "@emotion/utils": "^1.0.0",
-            "@floating-ui/react-dom": "^2.0.1",
-            "@radix-ui/react-dropdown-menu": "2.0.4",
-            "@types/gradient-parser": "0.1.3",
-            "@types/highlight-words-core": "1.2.1",
-            "@use-gesture/react": "^10.2.24",
-            "@wordpress/a11y": "^3.45.0",
-            "@wordpress/compose": "^6.22.0",
-            "@wordpress/date": "^4.45.0",
-            "@wordpress/deprecated": "^3.45.0",
-            "@wordpress/dom": "^3.45.0",
-            "@wordpress/element": "^5.22.0",
-            "@wordpress/escape-html": "^2.45.0",
-            "@wordpress/hooks": "^3.45.0",
-            "@wordpress/html-entities": "^3.45.0",
-            "@wordpress/i18n": "^4.45.0",
-            "@wordpress/icons": "^9.36.0",
-            "@wordpress/is-shallow-equal": "^4.45.0",
-            "@wordpress/keycodes": "^3.45.0",
-            "@wordpress/primitives": "^3.43.0",
-            "@wordpress/private-apis": "^0.27.0",
-            "@wordpress/rich-text": "^6.22.0",
-            "@wordpress/warning": "^2.45.0",
-            "change-case": "^4.1.2",
-            "classnames": "^2.3.1",
-            "colord": "^2.7.0",
-            "date-fns": "^2.28.0",
-            "deepmerge": "^4.3.0",
-            "dom-scroll-into-view": "^1.2.1",
-            "downshift": "^6.0.15",
-            "fast-deep-equal": "^3.1.3",
-            "framer-motion": "^10.13.0",
-            "gradient-parser": "^0.1.5",
-            "highlight-words-core": "^1.2.2",
-            "is-plain-object": "^5.0.0",
-            "memize": "^2.1.0",
-            "path-to-regexp": "^6.2.1",
-            "re-resizable": "^6.4.0",
-            "react-colorful": "^5.3.1",
-            "reakit": "^1.3.11",
-            "remove-accents": "^0.5.0",
-            "use-lilius": "^2.0.1",
-            "uuid": "^9.0.1",
-            "valtio": "1.7.0"
-          }
-        },
-        "@wordpress/notices": {
-          "version": "4.13.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/a11y": "^3.45.0",
-            "@wordpress/data": "^9.15.0"
-          }
-        },
-        "@wordpress/plugins": {
-          "version": "6.13.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/components": "^25.11.0",
-            "@wordpress/compose": "^6.22.0",
-            "@wordpress/element": "^5.22.0",
-            "@wordpress/hooks": "^3.45.0",
-            "@wordpress/icons": "^9.36.0",
-            "@wordpress/is-shallow-equal": "^4.45.0",
-            "memize": "^2.0.1"
-          }
-        },
-        "@wordpress/private-apis": {
-          "version": "0.27.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0"
-          }
-        },
-        "memize": {
-          "version": "2.1.0"
-        },
-        "path-to-regexp": {
-          "version": "6.2.1"
-        },
-        "remove-accents": {
-          "version": "0.5.0"
-        }
       }
     },
     "@wordpress/block-editor": {
@@ -48441,108 +47197,6 @@
         }
       }
     },
-    "@wordpress/customize-widgets": {
-      "version": "4.22.0",
-      "requires": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/block-editor": "^12.13.0",
-        "@wordpress/block-library": "^8.22.0",
-        "@wordpress/blocks": "^12.22.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/core-data": "^6.22.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/interface": "^5.22.0",
-        "@wordpress/is-shallow-equal": "^4.45.0",
-        "@wordpress/keyboard-shortcuts": "^4.22.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/media-utils": "^4.36.0",
-        "@wordpress/preferences": "^3.22.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/widgets": "^3.22.0",
-        "classnames": "^2.3.1",
-        "fast-deep-equal": "^3.1.3"
-      },
-      "dependencies": {
-        "@wordpress/components": {
-          "version": "25.11.0",
-          "requires": {
-            "@ariakit/react": "^0.3.5",
-            "@ariakit/test": "^0.3.0",
-            "@babel/runtime": "^7.16.0",
-            "@emotion/cache": "^11.7.1",
-            "@emotion/css": "^11.7.1",
-            "@emotion/react": "^11.7.1",
-            "@emotion/serialize": "^1.0.2",
-            "@emotion/styled": "^11.6.0",
-            "@emotion/utils": "^1.0.0",
-            "@floating-ui/react-dom": "^2.0.1",
-            "@radix-ui/react-dropdown-menu": "2.0.4",
-            "@types/gradient-parser": "0.1.3",
-            "@types/highlight-words-core": "1.2.1",
-            "@use-gesture/react": "^10.2.24",
-            "@wordpress/a11y": "^3.45.0",
-            "@wordpress/compose": "^6.22.0",
-            "@wordpress/date": "^4.45.0",
-            "@wordpress/deprecated": "^3.45.0",
-            "@wordpress/dom": "^3.45.0",
-            "@wordpress/element": "^5.22.0",
-            "@wordpress/escape-html": "^2.45.0",
-            "@wordpress/hooks": "^3.45.0",
-            "@wordpress/html-entities": "^3.45.0",
-            "@wordpress/i18n": "^4.45.0",
-            "@wordpress/icons": "^9.36.0",
-            "@wordpress/is-shallow-equal": "^4.45.0",
-            "@wordpress/keycodes": "^3.45.0",
-            "@wordpress/primitives": "^3.43.0",
-            "@wordpress/private-apis": "^0.27.0",
-            "@wordpress/rich-text": "^6.22.0",
-            "@wordpress/warning": "^2.45.0",
-            "change-case": "^4.1.2",
-            "classnames": "^2.3.1",
-            "colord": "^2.7.0",
-            "date-fns": "^2.28.0",
-            "deepmerge": "^4.3.0",
-            "dom-scroll-into-view": "^1.2.1",
-            "downshift": "^6.0.15",
-            "fast-deep-equal": "^3.1.3",
-            "framer-motion": "^10.13.0",
-            "gradient-parser": "^0.1.5",
-            "highlight-words-core": "^1.2.2",
-            "is-plain-object": "^5.0.0",
-            "memize": "^2.1.0",
-            "path-to-regexp": "^6.2.1",
-            "re-resizable": "^6.4.0",
-            "react-colorful": "^5.3.1",
-            "reakit": "^1.3.11",
-            "remove-accents": "^0.5.0",
-            "use-lilius": "^2.0.1",
-            "uuid": "^9.0.1",
-            "valtio": "1.7.0"
-          }
-        },
-        "@wordpress/private-apis": {
-          "version": "0.27.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0"
-          }
-        },
-        "memize": {
-          "version": "2.1.0"
-        },
-        "path-to-regexp": {
-          "version": "6.2.1"
-        },
-        "remove-accents": {
-          "version": "0.5.0"
-        }
-      }
-    },
     "@wordpress/data": {
       "version": "9.15.0",
       "requires": {
@@ -48569,15 +47223,6 @@
             "@babel/runtime": "^7.16.0"
           }
         }
-      }
-    },
-    "@wordpress/data-controls": {
-      "version": "2.30.0",
-      "requires": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/api-fetch": "^6.27.0",
-        "@wordpress/data": "^9.0.0",
-        "@wordpress/deprecated": "^3.30.0"
       }
     },
     "@wordpress/date": {
@@ -48679,285 +47324,6 @@
         "classnames": "^2.3.1",
         "memize": "^2.1.0",
         "rememo": "^4.0.2"
-      },
-      "dependencies": {
-        "@wordpress/components": {
-          "version": "25.11.0",
-          "requires": {
-            "@ariakit/react": "^0.3.5",
-            "@ariakit/test": "^0.3.0",
-            "@babel/runtime": "^7.16.0",
-            "@emotion/cache": "^11.7.1",
-            "@emotion/css": "^11.7.1",
-            "@emotion/react": "^11.7.1",
-            "@emotion/serialize": "^1.0.2",
-            "@emotion/styled": "^11.6.0",
-            "@emotion/utils": "^1.0.0",
-            "@floating-ui/react-dom": "^2.0.1",
-            "@radix-ui/react-dropdown-menu": "2.0.4",
-            "@types/gradient-parser": "0.1.3",
-            "@types/highlight-words-core": "1.2.1",
-            "@use-gesture/react": "^10.2.24",
-            "@wordpress/a11y": "^3.45.0",
-            "@wordpress/compose": "^6.22.0",
-            "@wordpress/date": "^4.45.0",
-            "@wordpress/deprecated": "^3.45.0",
-            "@wordpress/dom": "^3.45.0",
-            "@wordpress/element": "^5.22.0",
-            "@wordpress/escape-html": "^2.45.0",
-            "@wordpress/hooks": "^3.45.0",
-            "@wordpress/html-entities": "^3.45.0",
-            "@wordpress/i18n": "^4.45.0",
-            "@wordpress/icons": "^9.36.0",
-            "@wordpress/is-shallow-equal": "^4.45.0",
-            "@wordpress/keycodes": "^3.45.0",
-            "@wordpress/primitives": "^3.43.0",
-            "@wordpress/private-apis": "^0.27.0",
-            "@wordpress/rich-text": "^6.22.0",
-            "@wordpress/warning": "^2.45.0",
-            "change-case": "^4.1.2",
-            "classnames": "^2.3.1",
-            "colord": "^2.7.0",
-            "date-fns": "^2.28.0",
-            "deepmerge": "^4.3.0",
-            "dom-scroll-into-view": "^1.2.1",
-            "downshift": "^6.0.15",
-            "fast-deep-equal": "^3.1.3",
-            "framer-motion": "^10.13.0",
-            "gradient-parser": "^0.1.5",
-            "highlight-words-core": "^1.2.2",
-            "is-plain-object": "^5.0.0",
-            "memize": "^2.1.0",
-            "path-to-regexp": "^6.2.1",
-            "re-resizable": "^6.4.0",
-            "react-colorful": "^5.3.1",
-            "reakit": "^1.3.11",
-            "remove-accents": "^0.5.0",
-            "use-lilius": "^2.0.1",
-            "uuid": "^9.0.1",
-            "valtio": "1.7.0"
-          }
-        },
-        "@wordpress/notices": {
-          "version": "4.13.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/a11y": "^3.45.0",
-            "@wordpress/data": "^9.15.0"
-          }
-        },
-        "@wordpress/plugins": {
-          "version": "6.13.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/components": "^25.11.0",
-            "@wordpress/compose": "^6.22.0",
-            "@wordpress/element": "^5.22.0",
-            "@wordpress/hooks": "^3.45.0",
-            "@wordpress/icons": "^9.36.0",
-            "@wordpress/is-shallow-equal": "^4.45.0",
-            "memize": "^2.0.1"
-          }
-        },
-        "@wordpress/private-apis": {
-          "version": "0.27.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0"
-          }
-        },
-        "memize": {
-          "version": "2.1.0"
-        },
-        "path-to-regexp": {
-          "version": "6.2.1"
-        },
-        "remove-accents": {
-          "version": "0.5.0"
-        }
-      }
-    },
-    "@wordpress/edit-site": {
-      "version": "5.22.0",
-      "requires": {
-        "@babel/runtime": "^7.16.0",
-        "@tanstack/react-table": "^8.10.3",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/api-fetch": "^6.42.0",
-        "@wordpress/block-editor": "^12.13.0",
-        "@wordpress/block-library": "^8.22.0",
-        "@wordpress/blocks": "^12.22.0",
-        "@wordpress/commands": "^0.16.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/core-commands": "^0.14.0",
-        "@wordpress/core-data": "^6.22.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/date": "^4.45.0",
-        "@wordpress/deprecated": "^3.45.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/editor": "^13.22.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/escape-html": "^2.45.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/interface": "^5.22.0",
-        "@wordpress/keyboard-shortcuts": "^4.22.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/media-utils": "^4.36.0",
-        "@wordpress/notices": "^4.13.0",
-        "@wordpress/patterns": "^1.6.0",
-        "@wordpress/plugins": "^6.13.0",
-        "@wordpress/preferences": "^3.22.0",
-        "@wordpress/primitives": "^3.43.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/reusable-blocks": "^4.22.0",
-        "@wordpress/router": "^0.14.0",
-        "@wordpress/style-engine": "^1.28.0",
-        "@wordpress/url": "^3.46.0",
-        "@wordpress/viewport": "^5.22.0",
-        "@wordpress/widgets": "^3.22.0",
-        "@wordpress/wordcount": "^3.45.0",
-        "change-case": "^4.1.2",
-        "classnames": "^2.3.1",
-        "colord": "^2.9.2",
-        "deepmerge": "^4.3.0",
-        "downloadjs": "^1.4.7",
-        "fast-deep-equal": "^3.1.3",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "react-autosize-textarea": "^7.1.0",
-        "rememo": "^4.0.2",
-        "remove-accents": "^0.5.0"
-      },
-      "dependencies": {
-        "@wordpress/components": {
-          "version": "25.11.0",
-          "requires": {
-            "@ariakit/react": "^0.3.5",
-            "@ariakit/test": "^0.3.0",
-            "@babel/runtime": "^7.16.0",
-            "@emotion/cache": "^11.7.1",
-            "@emotion/css": "^11.7.1",
-            "@emotion/react": "^11.7.1",
-            "@emotion/serialize": "^1.0.2",
-            "@emotion/styled": "^11.6.0",
-            "@emotion/utils": "^1.0.0",
-            "@floating-ui/react-dom": "^2.0.1",
-            "@radix-ui/react-dropdown-menu": "2.0.4",
-            "@types/gradient-parser": "0.1.3",
-            "@types/highlight-words-core": "1.2.1",
-            "@use-gesture/react": "^10.2.24",
-            "@wordpress/a11y": "^3.45.0",
-            "@wordpress/compose": "^6.22.0",
-            "@wordpress/date": "^4.45.0",
-            "@wordpress/deprecated": "^3.45.0",
-            "@wordpress/dom": "^3.45.0",
-            "@wordpress/element": "^5.22.0",
-            "@wordpress/escape-html": "^2.45.0",
-            "@wordpress/hooks": "^3.45.0",
-            "@wordpress/html-entities": "^3.45.0",
-            "@wordpress/i18n": "^4.45.0",
-            "@wordpress/icons": "^9.36.0",
-            "@wordpress/is-shallow-equal": "^4.45.0",
-            "@wordpress/keycodes": "^3.45.0",
-            "@wordpress/primitives": "^3.43.0",
-            "@wordpress/private-apis": "^0.27.0",
-            "@wordpress/rich-text": "^6.22.0",
-            "@wordpress/warning": "^2.45.0",
-            "change-case": "^4.1.2",
-            "classnames": "^2.3.1",
-            "colord": "^2.7.0",
-            "date-fns": "^2.28.0",
-            "deepmerge": "^4.3.0",
-            "dom-scroll-into-view": "^1.2.1",
-            "downshift": "^6.0.15",
-            "fast-deep-equal": "^3.1.3",
-            "framer-motion": "^10.13.0",
-            "gradient-parser": "^0.1.5",
-            "highlight-words-core": "^1.2.2",
-            "is-plain-object": "^5.0.0",
-            "memize": "^2.1.0",
-            "path-to-regexp": "^6.2.1",
-            "re-resizable": "^6.4.0",
-            "react-colorful": "^5.3.1",
-            "reakit": "^1.3.11",
-            "remove-accents": "^0.5.0",
-            "use-lilius": "^2.0.1",
-            "uuid": "^9.0.1",
-            "valtio": "1.7.0"
-          }
-        },
-        "@wordpress/notices": {
-          "version": "4.13.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/a11y": "^3.45.0",
-            "@wordpress/data": "^9.15.0"
-          }
-        },
-        "@wordpress/plugins": {
-          "version": "6.13.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/components": "^25.11.0",
-            "@wordpress/compose": "^6.22.0",
-            "@wordpress/element": "^5.22.0",
-            "@wordpress/hooks": "^3.45.0",
-            "@wordpress/icons": "^9.36.0",
-            "@wordpress/is-shallow-equal": "^4.45.0",
-            "memize": "^2.0.1"
-          }
-        },
-        "@wordpress/private-apis": {
-          "version": "0.27.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0"
-          }
-        },
-        "memize": {
-          "version": "2.1.0"
-        },
-        "path-to-regexp": {
-          "version": "6.2.1"
-        },
-        "remove-accents": {
-          "version": "0.5.0"
-        }
-      }
-    },
-    "@wordpress/edit-widgets": {
-      "version": "5.22.0",
-      "requires": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/api-fetch": "^6.42.0",
-        "@wordpress/block-editor": "^12.13.0",
-        "@wordpress/block-library": "^8.22.0",
-        "@wordpress/blocks": "^12.22.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/core-data": "^6.22.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/deprecated": "^3.45.0",
-        "@wordpress/dom": "^3.45.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/hooks": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/interface": "^5.22.0",
-        "@wordpress/keyboard-shortcuts": "^4.22.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/media-utils": "^4.36.0",
-        "@wordpress/notices": "^4.13.0",
-        "@wordpress/patterns": "^1.6.0",
-        "@wordpress/plugins": "^6.13.0",
-        "@wordpress/preferences": "^3.22.0",
-        "@wordpress/private-apis": "^0.27.0",
-        "@wordpress/reusable-blocks": "^4.22.0",
-        "@wordpress/url": "^3.46.0",
-        "@wordpress/widgets": "^3.22.0",
-        "classnames": "^2.3.1"
       },
       "dependencies": {
         "@wordpress/components": {
@@ -49197,97 +47563,6 @@
         "@babel/runtime": "^7.16.0"
       }
     },
-    "@wordpress/format-library": {
-      "version": "4.22.0",
-      "requires": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.45.0",
-        "@wordpress/block-editor": "^12.13.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/data": "^9.15.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/html-entities": "^3.45.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/icons": "^9.36.0",
-        "@wordpress/rich-text": "^6.22.0",
-        "@wordpress/url": "^3.46.0"
-      },
-      "dependencies": {
-        "@wordpress/components": {
-          "version": "25.11.0",
-          "requires": {
-            "@ariakit/react": "^0.3.5",
-            "@ariakit/test": "^0.3.0",
-            "@babel/runtime": "^7.16.0",
-            "@emotion/cache": "^11.7.1",
-            "@emotion/css": "^11.7.1",
-            "@emotion/react": "^11.7.1",
-            "@emotion/serialize": "^1.0.2",
-            "@emotion/styled": "^11.6.0",
-            "@emotion/utils": "^1.0.0",
-            "@floating-ui/react-dom": "^2.0.1",
-            "@radix-ui/react-dropdown-menu": "2.0.4",
-            "@types/gradient-parser": "0.1.3",
-            "@types/highlight-words-core": "1.2.1",
-            "@use-gesture/react": "^10.2.24",
-            "@wordpress/a11y": "^3.45.0",
-            "@wordpress/compose": "^6.22.0",
-            "@wordpress/date": "^4.45.0",
-            "@wordpress/deprecated": "^3.45.0",
-            "@wordpress/dom": "^3.45.0",
-            "@wordpress/element": "^5.22.0",
-            "@wordpress/escape-html": "^2.45.0",
-            "@wordpress/hooks": "^3.45.0",
-            "@wordpress/html-entities": "^3.45.0",
-            "@wordpress/i18n": "^4.45.0",
-            "@wordpress/icons": "^9.36.0",
-            "@wordpress/is-shallow-equal": "^4.45.0",
-            "@wordpress/keycodes": "^3.45.0",
-            "@wordpress/primitives": "^3.43.0",
-            "@wordpress/private-apis": "^0.27.0",
-            "@wordpress/rich-text": "^6.22.0",
-            "@wordpress/warning": "^2.45.0",
-            "change-case": "^4.1.2",
-            "classnames": "^2.3.1",
-            "colord": "^2.7.0",
-            "date-fns": "^2.28.0",
-            "deepmerge": "^4.3.0",
-            "dom-scroll-into-view": "^1.2.1",
-            "downshift": "^6.0.15",
-            "fast-deep-equal": "^3.1.3",
-            "framer-motion": "^10.13.0",
-            "gradient-parser": "^0.1.5",
-            "highlight-words-core": "^1.2.2",
-            "is-plain-object": "^5.0.0",
-            "memize": "^2.1.0",
-            "path-to-regexp": "^6.2.1",
-            "re-resizable": "^6.4.0",
-            "react-colorful": "^5.3.1",
-            "reakit": "^1.3.11",
-            "remove-accents": "^0.5.0",
-            "use-lilius": "^2.0.1",
-            "uuid": "^9.0.1",
-            "valtio": "1.7.0"
-          }
-        },
-        "@wordpress/private-apis": {
-          "version": "0.27.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0"
-          }
-        },
-        "memize": {
-          "version": "2.1.0"
-        },
-        "path-to-regexp": {
-          "version": "6.2.1"
-        },
-        "remove-accents": {
-          "version": "0.5.0"
-        }
-      }
-    },
     "@wordpress/hooks": {
       "version": "3.45.0",
       "requires": {
@@ -49511,92 +47786,6 @@
         }
       }
     },
-    "@wordpress/list-reusable-blocks": {
-      "version": "4.22.0",
-      "requires": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/api-fetch": "^6.42.0",
-        "@wordpress/components": "^25.11.0",
-        "@wordpress/compose": "^6.22.0",
-        "@wordpress/element": "^5.22.0",
-        "@wordpress/i18n": "^4.45.0",
-        "change-case": "^4.1.2"
-      },
-      "dependencies": {
-        "@wordpress/components": {
-          "version": "25.11.0",
-          "requires": {
-            "@ariakit/react": "^0.3.5",
-            "@ariakit/test": "^0.3.0",
-            "@babel/runtime": "^7.16.0",
-            "@emotion/cache": "^11.7.1",
-            "@emotion/css": "^11.7.1",
-            "@emotion/react": "^11.7.1",
-            "@emotion/serialize": "^1.0.2",
-            "@emotion/styled": "^11.6.0",
-            "@emotion/utils": "^1.0.0",
-            "@floating-ui/react-dom": "^2.0.1",
-            "@radix-ui/react-dropdown-menu": "2.0.4",
-            "@types/gradient-parser": "0.1.3",
-            "@types/highlight-words-core": "1.2.1",
-            "@use-gesture/react": "^10.2.24",
-            "@wordpress/a11y": "^3.45.0",
-            "@wordpress/compose": "^6.22.0",
-            "@wordpress/date": "^4.45.0",
-            "@wordpress/deprecated": "^3.45.0",
-            "@wordpress/dom": "^3.45.0",
-            "@wordpress/element": "^5.22.0",
-            "@wordpress/escape-html": "^2.45.0",
-            "@wordpress/hooks": "^3.45.0",
-            "@wordpress/html-entities": "^3.45.0",
-            "@wordpress/i18n": "^4.45.0",
-            "@wordpress/icons": "^9.36.0",
-            "@wordpress/is-shallow-equal": "^4.45.0",
-            "@wordpress/keycodes": "^3.45.0",
-            "@wordpress/primitives": "^3.43.0",
-            "@wordpress/private-apis": "^0.27.0",
-            "@wordpress/rich-text": "^6.22.0",
-            "@wordpress/warning": "^2.45.0",
-            "change-case": "^4.1.2",
-            "classnames": "^2.3.1",
-            "colord": "^2.7.0",
-            "date-fns": "^2.28.0",
-            "deepmerge": "^4.3.0",
-            "dom-scroll-into-view": "^1.2.1",
-            "downshift": "^6.0.15",
-            "fast-deep-equal": "^3.1.3",
-            "framer-motion": "^10.13.0",
-            "gradient-parser": "^0.1.5",
-            "highlight-words-core": "^1.2.2",
-            "is-plain-object": "^5.0.0",
-            "memize": "^2.1.0",
-            "path-to-regexp": "^6.2.1",
-            "re-resizable": "^6.4.0",
-            "react-colorful": "^5.3.1",
-            "reakit": "^1.3.11",
-            "remove-accents": "^0.5.0",
-            "use-lilius": "^2.0.1",
-            "uuid": "^9.0.1",
-            "valtio": "1.7.0"
-          }
-        },
-        "@wordpress/private-apis": {
-          "version": "0.27.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0"
-          }
-        },
-        "memize": {
-          "version": "2.1.0"
-        },
-        "path-to-regexp": {
-          "version": "6.2.1"
-        },
-        "remove-accents": {
-          "version": "0.5.0"
-        }
-      }
-    },
     "@wordpress/media-utils": {
       "version": "4.36.0",
       "requires": {
@@ -49607,53 +47796,9 @@
         "@wordpress/i18n": "^4.45.0"
       }
     },
-    "@wordpress/notices": {
-      "version": "3.31.0",
-      "requires": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.31.0",
-        "@wordpress/data": "^9.1.0"
-      }
-    },
     "@wordpress/npm-package-json-lint-config": {
       "version": "4.30.0",
       "requires": {}
-    },
-    "@wordpress/nux": {
-      "version": "6.0.0",
-      "requires": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/components": "^23.0.0",
-        "@wordpress/compose": "^6.0.0",
-        "@wordpress/data": "^8.0.0",
-        "@wordpress/deprecated": "^3.23.0",
-        "@wordpress/element": "^5.0.0",
-        "@wordpress/i18n": "^4.23.0",
-        "@wordpress/icons": "^9.14.0",
-        "rememo": "^4.0.0"
-      },
-      "dependencies": {
-        "@wordpress/data": {
-          "version": "8.6.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/compose": "^6.6.0",
-            "@wordpress/deprecated": "^3.29.0",
-            "@wordpress/element": "^5.6.0",
-            "@wordpress/is-shallow-equal": "^4.29.0",
-            "@wordpress/priority-queue": "^2.29.0",
-            "@wordpress/private-apis": "^0.11.0",
-            "@wordpress/redux-routine": "^4.29.0",
-            "deepmerge": "^4.3.0",
-            "equivalent-key-map": "^0.2.2",
-            "is-plain-object": "^5.0.0",
-            "is-promise": "^4.0.0",
-            "redux": "^4.1.2",
-            "turbo-combine-reducers": "^1.0.2",
-            "use-memo-one": "^1.1.1"
-          }
-        }
-      }
     },
     "@wordpress/patterns": {
       "version": "1.6.0",
@@ -50827,131 +48972,6 @@
         "webpack-cli": "^5.1.4"
       },
       "dependencies": {
-        "@alleyinteractive/block-editor-tools": {
-          "version": "0.3.8",
-          "requires": {
-            "@alleyinteractive/tsconfig": "*",
-            "@wordpress/a11y": "^3.30.0",
-            "@wordpress/annotations": "^2.30.0",
-            "@wordpress/api-fetch": "^6.27.0",
-            "@wordpress/autop": "^3.30.0",
-            "@wordpress/blob": "^3.30.0",
-            "@wordpress/block-directory": "^4.7.0",
-            "@wordpress/block-editor": "^11.7.0",
-            "@wordpress/block-library": "^8.7.0",
-            "@wordpress/block-serialization-default-parser": "^4.30.0",
-            "@wordpress/blocks": "^12.7.0",
-            "@wordpress/components": "^23.7.0",
-            "@wordpress/compose": "^6.7.0",
-            "@wordpress/core-data": "^6.7.0",
-            "@wordpress/create-block": "^4.14.0",
-            "@wordpress/customize-widgets": "^4.7.0",
-            "@wordpress/data": "^9.0.0",
-            "@wordpress/data-controls": "^2.30.0",
-            "@wordpress/date": "^4.30.0",
-            "@wordpress/deprecated": "^3.30.0",
-            "@wordpress/dom": "^3.30.0",
-            "@wordpress/dom-ready": "^3.30.0",
-            "@wordpress/edit-post": "^7.7.0",
-            "@wordpress/edit-site": "^5.7.0",
-            "@wordpress/edit-widgets": "^5.7.0",
-            "@wordpress/element": "^5.7.0",
-            "@wordpress/escape-html": "^2.30.0",
-            "@wordpress/format-library": "^4.7.0",
-            "@wordpress/hooks": "^3.30.0",
-            "@wordpress/html-entities": "^3.30.0",
-            "@wordpress/i18n": "^4.30.0",
-            "@wordpress/icons": "^9.21.0",
-            "@wordpress/interface": "^5.7.0",
-            "@wordpress/is-shallow-equal": "^4.30.0",
-            "@wordpress/keyboard-shortcuts": "^4.7.0",
-            "@wordpress/keycodes": "^3.30.0",
-            "@wordpress/list-reusable-blocks": "^4.7.0",
-            "@wordpress/media-utils": "^4.21.0",
-            "@wordpress/notices": "^3.30.0",
-            "@wordpress/nux": "^6.0.0",
-            "@wordpress/plugins": "^5.7.0",
-            "@wordpress/primitives": "^3.28.0",
-            "@wordpress/priority-queue": "^2.30.0",
-            "@wordpress/redux-routine": "^4.30.0",
-            "@wordpress/reusable-blocks": "^4.7.0",
-            "@wordpress/rich-text": "^6.7.0",
-            "@wordpress/scripts": "^26.1.0",
-            "@wordpress/server-side-render": "^4.7.0",
-            "@wordpress/shortcode": "^3.30.0",
-            "@wordpress/token-list": "^2.30.0",
-            "@wordpress/url": "^3.31.0",
-            "@wordpress/viewport": "^5.7.0",
-            "@wordpress/warning": "^2.30.0",
-            "@wordpress/widgets": "^3.7.0",
-            "@wordpress/wordcount": "^3.30.0",
-            "classnames": "^2.3.2",
-            "dompurify": "^3.0.6",
-            "lodash": "^4.17.21",
-            "papaparse": "^5.4.0",
-            "prop-types": "^15.8.1",
-            "react": "18.2.0",
-            "styled-components": "^6.1.0",
-            "ts-loader": "^9.4.4",
-            "uuid": "^9.0.1",
-            "wp-types": "^3.62.4"
-          }
-        },
-        "@wordpress/block-editor": {
-          "version": "11.8.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@react-spring/web": "^9.4.5",
-            "@wordpress/a11y": "^3.31.0",
-            "@wordpress/api-fetch": "^6.28.0",
-            "@wordpress/blob": "^3.31.0",
-            "@wordpress/blocks": "^12.8.0",
-            "@wordpress/components": "^23.8.0",
-            "@wordpress/compose": "^6.8.0",
-            "@wordpress/data": "^9.1.0",
-            "@wordpress/date": "^4.31.0",
-            "@wordpress/deprecated": "^3.31.0",
-            "@wordpress/dom": "^3.31.0",
-            "@wordpress/element": "^5.8.0",
-            "@wordpress/escape-html": "^2.31.0",
-            "@wordpress/hooks": "^3.31.0",
-            "@wordpress/html-entities": "^3.31.0",
-            "@wordpress/i18n": "^4.31.0",
-            "@wordpress/icons": "^9.22.0",
-            "@wordpress/is-shallow-equal": "^4.31.0",
-            "@wordpress/keyboard-shortcuts": "^4.8.0",
-            "@wordpress/keycodes": "^3.31.0",
-            "@wordpress/notices": "^3.31.0",
-            "@wordpress/preferences": "^3.8.0",
-            "@wordpress/private-apis": "^0.13.0",
-            "@wordpress/rich-text": "^6.8.0",
-            "@wordpress/shortcode": "^3.31.0",
-            "@wordpress/style-engine": "^1.14.0",
-            "@wordpress/token-list": "^2.31.0",
-            "@wordpress/url": "^3.32.0",
-            "@wordpress/warning": "^2.31.0",
-            "@wordpress/wordcount": "^3.31.0",
-            "change-case": "^4.1.2",
-            "classnames": "^2.3.1",
-            "colord": "^2.7.0",
-            "diff": "^4.0.2",
-            "dom-scroll-into-view": "^1.2.1",
-            "fast-deep-equal": "^3.1.3",
-            "inherits": "^2.0.3",
-            "lodash": "^4.17.21",
-            "react-autosize-textarea": "^7.1.0",
-            "react-easy-crop": "^4.5.1",
-            "rememo": "^4.0.0",
-            "remove-accents": "^0.4.2",
-            "traverse": "^0.6.6"
-          }
-        },
-        "@wordpress/private-apis": {
-          "version": "0.13.0",
-          "requires": {
-            "@babel/runtime": "^7.16.0"
-          }
-        },
         "cross-spawn": {
           "version": "7.0.3",
           "requires": {
@@ -51643,7 +49663,8 @@
       }
     },
     "camelize": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -52281,7 +50302,8 @@
       "version": "1.1.1"
     },
     "css-color-keywords": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "css-declaration-sorter": {
       "version": "6.4.1",
@@ -52332,6 +50354,7 @@
     },
     "css-to-react-native": {
       "version": "3.2.0",
+      "dev": true,
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -52987,9 +51010,6 @@
     "dotenv-expand": {
       "version": "10.0.0",
       "dev": true
-    },
-    "downloadjs": {
-      "version": "1.4.7"
     },
     "downshift": {
       "version": "6.1.12",
@@ -58015,7 +56035,8 @@
       "dev": true
     },
     "papaparse": {
-      "version": "5.4.1"
+      "version": "5.4.1",
+      "dev": true
     },
     "param-case": {
       "version": "3.0.4",
@@ -59523,7 +57544,8 @@
       }
     },
     "shallowequal": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -60131,6 +58153,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.1.tgz",
       "integrity": "sha512-cpZZP5RrKRIClBW5Eby4JM1wElLVP4NQrJbJ0h10TidTyJf4SIIwa3zLXOoPb4gJi8MsJ8mjq5mu2IrEhZIAcQ==",
+      "dev": true,
       "requires": {
         "@emotion/is-prop-valid": "^1.2.1",
         "@emotion/unitless": "^0.8.0",
@@ -60144,7 +58167,8 @@
       },
       "dependencies": {
         "stylis": {
-          "version": "4.3.0"
+          "version": "4.3.0",
+          "dev": true
         }
       }
     },
@@ -60726,9 +58750,6 @@
     "tr46": {
       "version": "0.0.3"
     },
-    "traverse": {
-      "version": "0.6.7"
-    },
     "tree-kill": {
       "version": "1.2.2"
     },
@@ -60833,6 +58854,7 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
       "integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
+      "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.0.0",
@@ -60843,12 +58865,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -60856,31 +58880,37 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "dev": true
         },
         "enhanced-resolve": {
           "version": "5.12.0",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.4",
             "tapable": "^2.2.0"
           }
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "lru-cache": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.5.4",
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -60888,19 +58918,23 @@
         "source-map": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
+          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
         },
         "tapable": {
-          "version": "2.2.1"
+          "version": "2.2.1",
+          "dev": true
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         }
       }
     },
@@ -61784,6 +59818,7 @@
       "version": "3.64.0",
       "resolved": "https://registry.npmjs.org/wp-types/-/wp-types-3.64.0.tgz",
       "integrity": "sha512-8rwHUQFxI18jezvObymV0eKEhnU2xaSci5ra6YG+dV6EDZLfNR2z3NZA82mFkOzZRWpl/Dlj+a4u8aqk08UPGQ==",
+      "dev": true,
       "requires": {
         "typescript": ">=3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2896,10 +2896,11 @@
       "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.40.1",
-      "license": "MIT",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
+      "integrity": "sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==",
       "dependencies": {
-        "comment-parser": "1.4.0",
+        "comment-parser": "1.4.1",
         "esquery": "^1.5.0",
         "jsdoc-type-pratt-parser": "~4.0.0"
       },
@@ -2956,17 +2957,17 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.15",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3391,11 +3392,13 @@
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/topo": {
       "version": "5.1.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -4389,17 +4392,10 @@
         "node": ">=14"
       }
     },
-    "node_modules/@pkgr/utils": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "fast-glob": "^3.3.0",
-        "is-glob": "^4.0.3",
-        "open": "^9.1.0",
-        "picocolors": "^1.0.0",
-        "tslib": "^2.6.0"
-      },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
@@ -4407,80 +4403,13 @@
         "url": "https://opencollective.com/unts"
       }
     },
-    "node_modules/@pkgr/utils/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@pkgr/utils/node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@pkgr/utils/node_modules/open": {
-      "version": "9.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^4.0.0",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@pkgr/utils/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@pkgr/utils/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@pkgr/utils/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@playwright/test": {
-      "version": "1.39.0",
-      "license": "Apache-2.0",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.1.tgz",
+      "integrity": "sha512-9g8EWTjiQ9yFBXc6HjCWe41msLpxEX0KhmfmPl9RPLJdfzL4F0lg2BdJ91O9azFdl11y1pmpwdjBiSxvqc+btw==",
       "peer": true,
       "dependencies": {
-        "playwright": "1.39.0"
+        "playwright": "1.41.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4525,7 +4454,8 @@
     },
     "node_modules/@puppeteer/browsers": {
       "version": "1.4.6",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
+      "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -4552,7 +4482,8 @@
     },
     "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
       "version": "3.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
       "dependencies": {
         "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
@@ -4560,8 +4491,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/tar-stream": {
-      "version": "3.1.6",
-      "license": "MIT",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -5950,7 +5882,8 @@
     },
     "node_modules/@sentry/core": {
       "version": "6.19.7",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
+      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
       "dependencies": {
         "@sentry/hub": "6.19.7",
         "@sentry/minimal": "6.19.7",
@@ -5964,11 +5897,13 @@
     },
     "node_modules/@sentry/core/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/hub": {
       "version": "6.19.7",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
+      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
       "dependencies": {
         "@sentry/types": "6.19.7",
         "@sentry/utils": "6.19.7",
@@ -5980,11 +5915,13 @@
     },
     "node_modules/@sentry/hub/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/minimal": {
       "version": "6.19.7",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
+      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
       "dependencies": {
         "@sentry/hub": "6.19.7",
         "@sentry/types": "6.19.7",
@@ -5996,11 +5933,13 @@
     },
     "node_modules/@sentry/minimal/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
       "version": "6.19.7",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
+      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
       "dependencies": {
         "@sentry/core": "6.19.7",
         "@sentry/hub": "6.19.7",
@@ -6017,25 +5956,29 @@
     },
     "node_modules/@sentry/node/node_modules/cookie": {
       "version": "0.4.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/@sentry/node/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/types": {
       "version": "6.19.7",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
+      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
       "version": "6.19.7",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
+      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
       "dependencies": {
         "@sentry/types": "6.19.7",
         "tslib": "^1.9.3"
@@ -6046,22 +5989,26 @@
     },
     "node_modules/@sentry/utils/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@sideway/formula": {
       "version": "3.0.1",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -6350,21 +6297,6 @@
         }
       }
     },
-    "node_modules/@storybook/addon-controls/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@storybook/addon-controls/node_modules/@storybook/channels": {
       "version": "7.5.3",
       "dev": true,
@@ -6541,42 +6473,6 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@storybook/addon-controls/node_modules/esbuild": {
-      "version": "0.18.20",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
     },
     "node_modules/@storybook/addon-controls/node_modules/find-up": {
       "version": "5.0.0",
@@ -6928,21 +6824,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@storybook/addon-essentials/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@storybook/addon-essentials/node_modules/@storybook/channels": {
       "version": "7.5.3",
       "dev": true,
@@ -7119,42 +7000,6 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@storybook/addon-essentials/node_modules/esbuild": {
-      "version": "0.18.20",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
     },
     "node_modules/@storybook/addon-essentials/node_modules/find-up": {
       "version": "5.0.0",
@@ -8225,21 +8070,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@storybook/blocks/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@storybook/blocks/node_modules/@storybook/channels": {
       "version": "7.5.3",
       "dev": true,
@@ -8434,42 +8264,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@storybook/blocks/node_modules/esbuild": {
-      "version": "0.18.20",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
-    },
     "node_modules/@storybook/blocks/node_modules/find-up": {
       "version": "5.0.0",
       "dev": true,
@@ -8614,21 +8408,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-manager/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@storybook/builder-manager/node_modules/@storybook/channels": {
@@ -8779,42 +8558,6 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@storybook/builder-manager/node_modules/esbuild": {
-      "version": "0.18.20",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
     },
     "node_modules/@storybook/builder-manager/node_modules/find-up": {
       "version": "5.0.0",
@@ -8978,22 +8721,6 @@
         "vite-plugin-glimmerx": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@storybook/builder-vite/node_modules/@jridgewell/sourcemap-codec": {
@@ -9190,43 +8917,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/@storybook/builder-vite/node_modules/esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
     },
     "node_modules/@storybook/builder-vite/node_modules/find-up": {
       "version": "5.0.0",
@@ -9442,21 +9132,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/@storybook/cli/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@storybook/cli/node_modules/@storybook/channels": {
       "version": "7.5.1",
       "dev": true,
@@ -9653,42 +9328,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@storybook/cli/node_modules/esbuild": {
-      "version": "0.18.20",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
       }
     },
     "node_modules/@storybook/cli/node_modules/execa": {
@@ -10448,21 +10087,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/@storybook/core-common/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
       "version": "16.18.58",
       "dev": true,
@@ -10512,42 +10136,6 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@storybook/core-common/node_modules/esbuild": {
-      "version": "0.18.20",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
     },
     "node_modules/@storybook/core-common/node_modules/find-up": {
       "version": "5.0.0",
@@ -10730,21 +10318,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/core-server/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@storybook/core-server/node_modules/@storybook/channels": {
@@ -10940,42 +10513,6 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@storybook/core-server/node_modules/esbuild": {
-      "version": "0.18.20",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
     },
     "node_modules/@storybook/core-server/node_modules/find-up": {
       "version": "5.0.0",
@@ -11300,22 +10837,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/@storybook/docs-tools/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@storybook/docs-tools/node_modules/@storybook/channels": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.1.tgz",
@@ -11504,43 +11025,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/@storybook/docs-tools/node_modules/esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
     },
     "node_modules/@storybook/docs-tools/node_modules/find-up": {
       "version": "5.0.0",
@@ -12152,21 +11636,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/@storybook/telemetry/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@storybook/telemetry/node_modules/@storybook/channels": {
       "version": "7.5.1",
       "dev": true,
@@ -12335,42 +11804,6 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@storybook/telemetry/node_modules/esbuild": {
-      "version": "0.18.20",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
     },
     "node_modules/@storybook/telemetry/node_modules/find-up": {
       "version": "5.0.0",
@@ -13003,7 +12436,8 @@
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -14129,7 +13563,8 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.62.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
@@ -14153,7 +13588,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0"
@@ -14168,7 +13604,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -14179,7 +13616,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.62.0",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0",
@@ -14204,7 +13642,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.62.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -14219,7 +13658,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -14229,7 +13669,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14239,7 +13680,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
       "version": "7.5.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -14252,7 +13694,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "6.13.1",
@@ -14484,12 +13927,13 @@
       }
     },
     "node_modules/@wordpress/api-fetch": {
-      "version": "6.42.0",
-      "license": "GPL-2.0-or-later",
+      "version": "6.46.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.46.0.tgz",
+      "integrity": "sha512-SimHPw57N8LyZpQB6dK5xq1Kn1WtqP/K27GjGwvxvkb+8xbVv0TI67AF9adsN4sZbOHIZJQwqvCTSGKhNttAvQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/url": "^3.46.0"
+        "@wordpress/i18n": "^4.49.0",
+        "@wordpress/url": "^3.50.0"
       },
       "engines": {
         "node": ">=12"
@@ -14506,8 +13950,9 @@
       }
     },
     "node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
-      "version": "4.28.0",
-      "license": "GPL-2.0-or-later",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.32.0.tgz",
+      "integrity": "sha512-ie6p5VpUxTNMPQrHdCYEPddTzmDeFTQjFi3qq17set9WbRAMaOZ8jqQhSxms0NJi8Xa6wZM9TR2ZABAlg+FTeA==",
       "engines": {
         "node": ">=14"
       },
@@ -14516,8 +13961,9 @@
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "7.29.0",
-      "license": "GPL-2.0-or-later",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.33.0.tgz",
+      "integrity": "sha512-/OonEa67xJdIn0ADWEd7AJtLhIGlYALKyc17RxTmI2Ojs0zLIQNbgAv1D/cuVguo0UKK9zsMZ9MBkhSKLF9A9Q==",
       "dependencies": {
         "@babel/core": "^7.16.0",
         "@babel/plugin-transform-react-jsx": "^7.16.0",
@@ -14525,9 +13971,9 @@
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
         "@babel/runtime": "^7.16.0",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^4.28.0",
-        "@wordpress/browserslist-config": "^5.28.0",
-        "@wordpress/warning": "^2.45.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^4.32.0",
+        "@wordpress/browserslist-config": "^5.32.0",
+        "@wordpress/warning": "^2.49.0",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.2.0"
@@ -14537,8 +13983,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "4.36.0",
-      "license": "GPL-2.0-or-later"
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.40.0.tgz",
+      "integrity": "sha512-A+HiyES4YjfbFhJAGrhCLB3QWomgWZR9wkgG7K9l6DD70/9Vd7t+go7jI1HJ1c9qGfBV0rmdQf/qNn89Aai1cg=="
     },
     "node_modules/@wordpress/blob": {
       "version": "3.45.0",
@@ -14936,8 +14383,9 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "5.28.0",
-      "license": "GPL-2.0-or-later",
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.32.0.tgz",
+      "integrity": "sha512-LrL4Zg/abXYfVwwbx1caugz4J1GUL+6WNqVF1MZQVDm6CHdlpTEQOvvr/KEi9mN1UY2YoTlxZtUxzvNRTo2Fsg==",
       "engines": {
         "node": ">=14"
       }
@@ -15416,8 +14864,9 @@
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "4.28.0",
-      "license": "GPL-2.0-or-later",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.31.0.tgz",
+      "integrity": "sha512-Xpm8EEhi6e8GL1juYh/70AFbcE/ZVXJ3p47KMkkEsn5t+hG9QHjKe2lTj98v2r3rB+ampoK+whdV1w6gItXYpw==",
       "dependencies": {
         "json2php": "^0.0.7",
         "webpack-sources": "^3.2.2"
@@ -15462,17 +14911,19 @@
       }
     },
     "node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "0.13.0",
-      "license": "GPL-2.0-or-later",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.16.0.tgz",
+      "integrity": "sha512-CktRj5/Cc/pAvTHXIAPIMrmmnb0VjtXbTGSjYG6pW/JI2YAmpwY2yBA+DlHJjqOIpcjDDj+sSsJomRSxT2chwQ==",
       "dependencies": {
-        "@wordpress/api-fetch": "^6.42.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/url": "^3.46.0",
+        "@wordpress/api-fetch": "^6.45.0",
+        "@wordpress/keycodes": "^3.48.0",
+        "@wordpress/url": "^3.49.0",
         "change-case": "^4.1.2",
         "form-data": "^4.0.0",
         "get-port": "^5.1.1",
         "lighthouse": "^10.4.0",
-        "mime": "^3.0.0"
+        "mime": "^3.0.0",
+        "web-vitals": "^3.5.0"
       },
       "engines": {
         "node": ">=12"
@@ -15483,7 +14934,8 @@
     },
     "node_modules/@wordpress/e2e-test-utils-playwright/node_modules/form-data": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -15495,7 +14947,8 @@
     },
     "node_modules/@wordpress/e2e-test-utils-playwright/node_modules/mime": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "bin": {
         "mime": "cli.js"
       },
@@ -15852,8 +15305,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "3.45.0",
-      "license": "GPL-2.0-or-later",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.49.0.tgz",
+      "integrity": "sha512-GH546Jg8u/rw9I3fsvAhidwt8rUFNmkdXGByIPGsN3R6y+QwWMXPzsnoYdFmFOmDK9gOGCRDe5bXHikoWnaiKA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -15872,11 +15326,12 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "4.45.0",
-      "license": "GPL-2.0-or-later",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.49.0.tgz",
+      "integrity": "sha512-8aZmmRfOHzS/3pMWg+4f6QlPci0wK5V+PDllAwtwFFrXgc0pmk8VXu7Quajh1tiVoIQDCZpK6h1sqa+qrCLpZg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.45.0",
+        "@wordpress/hooks": "^3.49.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "sprintf-js": "^1.1.1",
@@ -16066,8 +15521,9 @@
       }
     },
     "node_modules/@wordpress/jest-console": {
-      "version": "7.16.0",
-      "license": "GPL-2.0-or-later",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.20.0.tgz",
+      "integrity": "sha512-EXexYwBLaJSpSCUwpQeSqjJ9G7KDkzH+oCfiZp4ZYuemmCaJFOn8/HOLwfLU0o7i0bfYFAjt8lSVCr5HiYY0AA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "jest-matcher-utils": "^29.6.2"
@@ -16080,10 +15536,11 @@
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
-      "version": "11.16.0",
-      "license": "GPL-2.0-or-later",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.20.0.tgz",
+      "integrity": "sha512-3x2ua/rc0540zfLOrHbfdrEOwS5xWPbX5/f2LUyM2T6zzmhXrnqG2WFdhftFFLAUhC8cbxuy1WNnrzgjUxGeDQ==",
       "dependencies": {
-        "@wordpress/jest-console": "^7.16.0",
+        "@wordpress/jest-console": "^7.20.0",
         "babel-jest": "^29.6.2"
       },
       "engines": {
@@ -16112,12 +15569,12 @@
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "3.45.0",
-      "license": "GPL-2.0-or-later",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.49.0.tgz",
+      "integrity": "sha512-Hg+kUTV/ti+CyG4+D3dmRFMmrE45E2QEv7ZKaeIf+t1wlafekLSDwIpdF7e68HxEMmZSzHmLm7bHqQTNjxAoKQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.45.0",
-        "change-case": "^4.1.2"
+        "@wordpress/i18n": "^4.49.0"
       },
       "engines": {
         "node": ">=12"
@@ -16181,8 +15638,9 @@
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
-      "version": "4.30.0",
-      "license": "GPL-2.0-or-later",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.34.0.tgz",
+      "integrity": "sha512-mknDw+d5HIfx/1DyrhkbLJNu8XsmUEjc1SsYSgF2XCP20/khpO7YOi0LWn9uQ2QXWZrlhMc7JKSSOcTs0aLphQ==",
       "engines": {
         "node": ">=14"
       },
@@ -16340,10 +15798,11 @@
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "4.29.0",
-      "license": "GPL-2.0-or-later",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.33.0.tgz",
+      "integrity": "sha512-RqKNf8XQTdae0cXO11l6mBw+A3IOEO9dd4sD70g15e4IltrbwuxqwOT5k9muNteUszTCOQKgWgD8gp1KM2/lvQ==",
       "dependencies": {
-        "@wordpress/base-styles": "^4.36.0",
+        "@wordpress/base-styles": "^4.40.0",
         "autoprefixer": "^10.2.5"
       },
       "engines": {
@@ -16692,22 +16151,23 @@
       }
     },
     "node_modules/@wordpress/scripts": {
-      "version": "26.16.0",
-      "license": "GPL-2.0-or-later",
+      "version": "26.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-26.19.0.tgz",
+      "integrity": "sha512-m3QYlgpWRfIqCfU4jWKwGeA12Qkt6d9CMewEIxIBGVlEGd/sL5rU1fM7LKNBEbSPQpaOTWJApNGWPcW75Fwp+w==",
       "dependencies": {
         "@babel/core": "^7.16.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^7.29.0",
-        "@wordpress/browserslist-config": "^5.28.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^4.28.0",
-        "@wordpress/e2e-test-utils-playwright": "^0.13.0",
-        "@wordpress/eslint-plugin": "^17.2.0",
-        "@wordpress/jest-preset-default": "^11.16.0",
-        "@wordpress/npm-package-json-lint-config": "^4.30.0",
-        "@wordpress/postcss-plugins-preset": "^4.29.0",
-        "@wordpress/prettier-config": "^3.2.0",
-        "@wordpress/stylelint-config": "^21.28.0",
+        "@wordpress/babel-preset-default": "^7.32.0",
+        "@wordpress/browserslist-config": "^5.31.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^4.31.0",
+        "@wordpress/e2e-test-utils-playwright": "^0.16.0",
+        "@wordpress/eslint-plugin": "^17.5.0",
+        "@wordpress/jest-preset-default": "^11.19.0",
+        "@wordpress/npm-package-json-lint-config": "^4.33.0",
+        "@wordpress/postcss-plugins-preset": "^4.32.0",
+        "@wordpress/prettier-config": "^3.5.0",
+        "@wordpress/stylelint-config": "^21.31.0",
         "adm-zip": "^0.5.9",
         "babel-jest": "^29.6.2",
         "babel-loader": "^8.2.3",
@@ -16726,7 +16186,7 @@
         "fast-glob": "^3.2.7",
         "filenamify": "^4.2.0",
         "jest": "^29.6.2",
-        "jest-dev-server": "^6.0.2",
+        "jest-dev-server": "^9.0.1",
         "jest-environment-jsdom": "^29.6.2",
         "jest-environment-node": "^29.6.2",
         "markdownlint-cli": "^0.31.1",
@@ -16735,7 +16195,7 @@
         "minimist": "^1.2.0",
         "npm-package-json-lint": "^6.4.0",
         "npm-packlist": "^3.0.0",
-        "playwright-core": "1.32.0",
+        "playwright-core": "1.39.0",
         "postcss": "^8.4.5",
         "postcss-loader": "^6.2.1",
         "prettier": "npm:wp-prettier@3.0.3",
@@ -16762,7 +16222,7 @@
         "npm": ">=6.14.4"
       },
       "peerDependencies": {
-        "@playwright/test": "^1.32.0",
+        "@playwright/test": "^1.39.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
@@ -16853,14 +16313,15 @@
       }
     },
     "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin": {
-      "version": "17.2.0",
-      "license": "GPL-2.0-or-later",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-17.6.0.tgz",
+      "integrity": "sha512-piANQS5eaSPmpzPXdNZdXbKcHjAyXbuHeUd9ctVA+6sOMVay70+ICQj7Isu4o61Wv43KtxugQoa2PSBqVtrRKA==",
       "dependencies": {
         "@babel/eslint-parser": "^7.16.0",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
-        "@wordpress/babel-preset-default": "^7.29.0",
-        "@wordpress/prettier-config": "^3.2.0",
+        "@wordpress/babel-preset-default": "^7.33.0",
+        "@wordpress/prettier-config": "^3.6.0",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.2",
@@ -16894,8 +16355,9 @@
       }
     },
     "node_modules/@wordpress/scripts/node_modules/@wordpress/prettier-config": {
-      "version": "3.2.0",
-      "license": "GPL-2.0-or-later",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.6.0.tgz",
+      "integrity": "sha512-51GuCeeEGOi4qsMpzGFBmKbqEUKLqWj3eZDIwATymUaHsJPx9oT93dlIP97MqKIaWjxlhxCMt5RjxcCNT7Pckw==",
       "engines": {
         "node": ">=14"
       },
@@ -17049,21 +16511,23 @@
       }
     },
     "node_modules/@wordpress/scripts/node_modules/eslint-plugin-prettier": {
-      "version": "5.0.1",
-      "license": "MIT",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
+      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.8.5"
+        "synckit": "^0.8.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://opencollective.com/prettier"
+        "url": "https://opencollective.com/eslint-plugin-prettier"
       },
       "peerDependencies": {
         "@types/eslint": ">=8.0.0",
         "eslint": ">=8.0.0",
+        "eslint-config-prettier": "*",
         "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
@@ -17100,8 +16564,9 @@
       }
     },
     "node_modules/@wordpress/scripts/node_modules/globals": {
-      "version": "13.23.0",
-      "license": "MIT",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -17114,7 +16579,8 @@
     },
     "node_modules/@wordpress/scripts/node_modules/globals/node_modules/type-fest": {
       "version": "0.20.2",
-      "license": "(MIT OR CC0-1.0)",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "engines": {
         "node": ">=10"
       },
@@ -17243,7 +16709,8 @@
     "node_modules/@wordpress/scripts/node_modules/prettier": {
       "name": "wp-prettier",
       "version": "3.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
+      "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17500,8 +16967,9 @@
       }
     },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "21.28.0",
-      "license": "MIT",
+      "version": "21.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.32.0.tgz",
+      "integrity": "sha512-cmrzU55alv+OZu1fXBC2eZGgJIUwyD47TSDDP7l0o9yF6D/w0am7FxC9ungk/S2uK1oatN05nIPsFSTkuHQSzg==",
       "dependencies": {
         "stylelint-config-recommended": "^6.0.0",
         "stylelint-config-recommended-scss": "^5.0.2"
@@ -17554,8 +17022,9 @@
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "3.46.0",
-      "license": "GPL-2.0-or-later",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.50.0.tgz",
+      "integrity": "sha512-+YQzsPim5Zx55o/y9urtd0CKANUgwqZSdUNjDWYZ/1CWxtLLzPgQJOabtl79hG2yjrKvjDe9PrDPff18bCmG5A==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "remove-accents": "^0.5.0"
@@ -17585,8 +17054,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "2.45.0",
-      "license": "GPL-2.0-or-later",
+      "version": "2.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.49.0.tgz",
+      "integrity": "sha512-W2Nj9Nj0o2udPLf8jfGijRff3lzQgPOiLZcN4LFUPT6yyb9MxvNIg7ZVTBJL2TB78+KQKGrIH4ERjV5WyDRoEQ==",
       "engines": {
         "node": ">=12"
       }
@@ -17901,7 +17371,8 @@
     },
     "node_modules/ajv-errors": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
       "peerDependencies": {
         "ajv": ">=5.0.0"
       }
@@ -18025,7 +17496,8 @@
     },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
       "engines": {
         "node": ">=14"
       }
@@ -18230,6 +17702,17 @@
         "util": "^0.12.5"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "license": "MIT"
@@ -18319,10 +17802,26 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.25.0",
-      "license": "MIT",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -18334,7 +17833,8 @@
     },
     "node_modules/b4a": {
       "version": "1.6.4",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
     },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
@@ -18744,8 +18244,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.3",
-      "license": "MIT",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
+      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -18778,6 +18279,7 @@
     },
     "node_modules/big-integer": {
       "version": "1.6.51",
+      "dev": true,
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
@@ -18866,6 +18368,7 @@
     },
     "node_modules/bplist-parser": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "big-integer": "^1.6.44"
@@ -18995,7 +18498,8 @@
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "engines": {
         "node": ">=6"
       },
@@ -19007,19 +18511,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ=="
-    },
-    "node_modules/bundle-name": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/bytes": {
       "version": "3.0.0",
@@ -19342,7 +18833,8 @@
     },
     "node_modules/chrome-launcher": {
       "version": "0.15.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+      "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
       "dependencies": {
         "@types/node": "*",
         "escape-string-regexp": "^4.0.0",
@@ -19358,7 +18850,8 @@
     },
     "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
       },
@@ -19375,7 +18868,8 @@
     },
     "node_modules/chromium-bidi": {
       "version": "0.4.16",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
+      "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
       "dependencies": {
         "mitt": "3.0.0"
       },
@@ -19647,8 +19141,9 @@
       }
     },
     "node_modules/comment-parser": {
-      "version": "1.4.0",
-      "license": "MIT",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -19761,7 +19256,8 @@
     },
     "node_modules/configstore": {
       "version": "5.0.1",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
       "dependencies": {
         "dot-prop": "^5.2.0",
         "graceful-fs": "^4.1.2",
@@ -19776,7 +19272,8 @@
     },
     "node_modules/configstore/node_modules/make-dir": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -19789,14 +19286,16 @@
     },
     "node_modules/configstore/node_modules/semver": {
       "version": "6.3.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/configstore/node_modules/write-file-atomic": {
       "version": "3.0.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",
@@ -20114,7 +19613,8 @@
     },
     "node_modules/csp_evaluator": {
       "version": "1.1.1",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.1.tgz",
+      "integrity": "sha512-N3ASg0C4kNPUaNxt1XAvzHIVuzdtr8KLgfk1O8WDyimp1GisPAHESupArO2ieHk9QWbrJ/WkQODyh21Ps/xhxw=="
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
@@ -20396,7 +19896,8 @@
     },
     "node_modules/cwd": {
       "version": "0.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
+      "integrity": "sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==",
       "dependencies": {
         "find-pkg": "^0.1.2",
         "fs-exists-sync": "^0.1.0"
@@ -20411,7 +19912,8 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.1.tgz",
+      "integrity": "sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg==",
       "engines": {
         "node": ">= 14"
       }
@@ -20594,24 +20096,9 @@
         }
       }
     },
-    "node_modules/default-browser": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^3.0.0",
-        "default-browser-id": "^3.0.0",
-        "execa": "^7.1.1",
-        "titleize": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/default-browser-id": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bplist-parser": "^0.2.0",
@@ -20622,152 +20109,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/default-browser/node_modules/execa": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^4.3.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^3.0.7",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/default-browser/node_modules/get-stream": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/human-signals": {
-      "version": "4.3.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/default-browser/node_modules/is-stream": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/npm-run-path": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/onetime": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/default-browser/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/default-browser/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/default-gateway": {
@@ -20912,7 +20253,8 @@
     },
     "node_modules/degenerator": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -20920,16 +20262,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/degenerator/node_modules/ast-types": {
-      "version": "0.13.4",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/del": {
@@ -21316,7 +20648,8 @@
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "dependencies": {
         "is-obj": "^2.0.0"
       },
@@ -21672,11 +21005,11 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.17.15",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
       "devOptional": true,
       "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -21684,28 +21017,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.15",
-        "@esbuild/android-arm64": "0.17.15",
-        "@esbuild/android-x64": "0.17.15",
-        "@esbuild/darwin-arm64": "0.17.15",
-        "@esbuild/darwin-x64": "0.17.15",
-        "@esbuild/freebsd-arm64": "0.17.15",
-        "@esbuild/freebsd-x64": "0.17.15",
-        "@esbuild/linux-arm": "0.17.15",
-        "@esbuild/linux-arm64": "0.17.15",
-        "@esbuild/linux-ia32": "0.17.15",
-        "@esbuild/linux-loong64": "0.17.15",
-        "@esbuild/linux-mips64el": "0.17.15",
-        "@esbuild/linux-ppc64": "0.17.15",
-        "@esbuild/linux-riscv64": "0.17.15",
-        "@esbuild/linux-s390x": "0.17.15",
-        "@esbuild/linux-x64": "0.17.15",
-        "@esbuild/netbsd-x64": "0.17.15",
-        "@esbuild/openbsd-x64": "0.17.15",
-        "@esbuild/sunos-x64": "0.17.15",
-        "@esbuild/win32-arm64": "0.17.15",
-        "@esbuild/win32-ia32": "0.17.15",
-        "@esbuild/win32-x64": "0.17.15"
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
       }
     },
     "node_modules/esbuild-plugin-alias": {
@@ -21722,363 +21055,6 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.12 <1"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.15.tgz",
-      "integrity": "sha512-sRSOVlLawAktpMvDyJIkdLI/c/kdRTOqo8t6ImVxg8yT7LQDUYV5Rp2FKeEosLr6ZCja9UjYAzyRSxGteSJPYg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.15.tgz",
-      "integrity": "sha512-0kOB6Y7Br3KDVgHeg8PRcvfLkq+AccreK///B4Z6fNZGr/tNHX0z2VywCc7PTeWp+bPvjA5WMvNXltHw5QjAIA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.15.tgz",
-      "integrity": "sha512-MzDqnNajQZ63YkaUWVl9uuhcWyEyh69HGpMIrf+acR4otMkfLJ4sUCxqwbCyPGicE9dVlrysI3lMcDBjGiBBcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.15.tgz",
-      "integrity": "sha512-NbImBas2rXwYI52BOKTW342Tm3LTeVlaOQ4QPZ7XuWNKiO226DisFk/RyPk3T0CKZkKMuU69yOvlapJEmax7cg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.15.tgz",
-      "integrity": "sha512-Xk9xMDjBVG6CfgoqlVczHAdJnCs0/oeFOspFap5NkYAmRCT2qTn1vJWA2f419iMtsHSLm+O8B6SLV/HlY5cYKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.15.tgz",
-      "integrity": "sha512-3TWAnnEOdclvb2pnfsTWtdwthPfOz7qAfcwDLcfZyGJwm1SRZIMOeB5FODVhnM93mFSPsHB9b/PmxNNbSnd0RQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.15.tgz",
-      "integrity": "sha512-MLTgiXWEMAMr8nmS9Gigx43zPRmEfeBfGCwxFQEMgJ5MC53QKajaclW6XDPjwJvhbebv+RzK05TQjvH3/aM4Xw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.15.tgz",
-      "integrity": "sha512-T0MVnYw9KT6b83/SqyznTs/3Jg2ODWrZfNccg11XjDehIved2oQfrX/wVuev9N936BpMRaTR9I1J0tdGgUgpJA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.15.tgz",
-      "integrity": "sha512-wp02sHs015T23zsQtU4Cj57WiteiuASHlD7rXjKUyAGYzlOKDAjqK6bk5dMi2QEl/KVOcsjwL36kD+WW7vJt8Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.15.tgz",
-      "integrity": "sha512-k7FsUJjGGSxwnBmMh8d7IbObWu+sF/qbwc+xKZkBe/lTAF16RqxRCnNHA7QTd3oS2AfGBAnHlXL67shV5bBThQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.15.tgz",
-      "integrity": "sha512-ZLWk6czDdog+Q9kE/Jfbilu24vEe/iW/Sj2d8EVsmiixQ1rM2RKH2n36qfxK4e8tVcaXkvuV3mU5zTZviE+NVQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.15.tgz",
-      "integrity": "sha512-mY6dPkIRAiFHRsGfOYZC8Q9rmr8vOBZBme0/j15zFUKM99d4ILY4WpOC7i/LqoY+RE7KaMaSfvY8CqjJtuO4xg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.15.tgz",
-      "integrity": "sha512-EcyUtxffdDtWjjwIH8sKzpDRLcVtqANooMNASO59y+xmqqRYBBM7xVLQhqF7nksIbm2yHABptoioS9RAbVMWVA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.15.tgz",
-      "integrity": "sha512-BuS6Jx/ezxFuHxgsfvz7T4g4YlVrmCmg7UAwboeyNNg0OzNzKsIZXpr3Sb/ZREDXWgt48RO4UQRDBxJN3B9Rbg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.15.tgz",
-      "integrity": "sha512-JsdS0EgEViwuKsw5tiJQo9UdQdUJYuB+Mf6HxtJSPN35vez1hlrNb1KajvKWF5Sa35j17+rW1ECEO9iNrIXbNg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.15.tgz",
-      "integrity": "sha512-R6fKjtUysYGym6uXf6qyNephVUQAGtf3n2RCsOST/neIwPqRWcnc3ogcielOd6pT+J0RDR1RGcy0ZY7d3uHVLA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.15.tgz",
-      "integrity": "sha512-mVD4PGc26b8PI60QaPUltYKeSX0wxuy0AltC+WCTFwvKCq2+OgLP4+fFd+hZXzO2xW1HPKcytZBdjqL6FQFa7w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.15.tgz",
-      "integrity": "sha512-U6tYPovOkw3459t2CBwGcFYfFRjivcJJc1WC8Q3funIwX8x4fP+R6xL/QuTPNGOblbq/EUDxj9GU+dWKX0oWlQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.15.tgz",
-      "integrity": "sha512-W+Z5F++wgKAleDABemiyXVnzXgvRFs+GVKThSI+mGgleLWluv0D7Diz4oQpgdpNzh4i2nNDzQtWbjJiqutRp6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.15.tgz",
-      "integrity": "sha512-Muz/+uGgheShKGqSVS1KsHtCyEzcdOn/W/Xbh6H91Etm+wiIfwZaBn1W58MeGtfI8WA961YMHFYTthBdQs4t+w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.15.tgz",
-      "integrity": "sha512-DjDa9ywLUUmjhV2Y9wUTIF+1XsmuFGvZoCmOWkli1XcNAh5t25cc7fgsCx4Zi/Uurep3TTLyDiKATgGEg61pkA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/escalade": {
@@ -22237,7 +21213,8 @@
     },
     "node_modules/eslint-config-prettier": {
       "version": "8.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -22400,8 +21377,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "27.6.0",
-      "license": "MIT",
+      "version": "27.6.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.6.3.tgz",
+      "integrity": "sha512-+YsJFVH6R+tOiO3gCJon5oqn4KWc+mDq2leudk8mrp8RFubLOo9CVyi3cib4L7XMpxExmkmBZQTPDYVBzgpgOA==",
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
       },
@@ -22423,29 +21401,31 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "46.8.2",
-      "license": "BSD-3-Clause",
+      "version": "46.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
+      "integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.40.1",
+        "@es-joy/jsdoccomment": "~0.41.0",
         "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.0",
+        "comment-parser": "1.4.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.5.0",
         "is-builtin-module": "^3.2.1",
         "semver": "^7.5.4",
-        "spdx-expression-parse": "^3.0.1"
+        "spdx-expression-parse": "^4.0.0"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
       },
@@ -22455,7 +21435,8 @@
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -22465,7 +21446,8 @@
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
       "version": "7.5.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -22476,9 +21458,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint-plugin-jsdoc/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/eslint-plugin-jsdoc/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.8.0",
@@ -22521,7 +21513,8 @@
     },
     "node_modules/eslint-plugin-playwright": {
       "version": "0.15.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
+      "integrity": "sha512-LQMW5y0DLK5Fnpya7JR1oAYL2/7Y9wDiYw6VZqlKqcRGSgjbVKNqxraphk7ra1U3Bb5EK444xMgUlQPbMg2M1g==",
       "peerDependencies": {
         "eslint": ">=7",
         "eslint-plugin-jest": ">=25"
@@ -23030,7 +22023,8 @@
     },
     "node_modules/expand-tilde": {
       "version": "1.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "integrity": "sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==",
       "dependencies": {
         "os-homedir": "^1.0.1"
       },
@@ -23164,11 +22158,13 @@
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -23422,7 +22418,8 @@
     },
     "node_modules/find-file-up": {
       "version": "0.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+      "integrity": "sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==",
       "dependencies": {
         "fs-exists-sync": "^0.1.0",
         "resolve-dir": "^0.1.0"
@@ -23437,7 +22434,8 @@
     },
     "node_modules/find-pkg": {
       "version": "0.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+      "integrity": "sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==",
       "dependencies": {
         "find-file-up": "^0.1.2"
       },
@@ -23447,7 +22445,8 @@
     },
     "node_modules/find-process": {
       "version": "1.4.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+      "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
       "dependencies": {
         "chalk": "^4.0.0",
         "commander": "^5.1.0",
@@ -23459,7 +22458,8 @@
     },
     "node_modules/find-process/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -23472,7 +22472,8 @@
     },
     "node_modules/find-process/node_modules/chalk": {
       "version": "4.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -23486,7 +22487,8 @@
     },
     "node_modules/find-process/node_modules/color-convert": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -23496,25 +22498,29 @@
     },
     "node_modules/find-process/node_modules/color-name": {
       "version": "1.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/find-process/node_modules/commander": {
       "version": "5.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/find-process/node_modules/has-flag": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/find-process/node_modules/supports-color": {
       "version": "7.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -23580,14 +22586,15 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -23700,7 +22707,8 @@
     },
     "node_modules/fs-exists-sync": {
       "version": "0.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23896,7 +22904,8 @@
     },
     "node_modules/get-uri": {
       "version": "6.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.2.tgz",
+      "integrity": "sha512-5KLucCJobh8vBY1K07EFV4+cPZH3mrV9YeAruUseCQKHB58SGjjT2l9/eA9LD082IiuMjSlFJEcdJ27TXvbZNw==",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.0",
@@ -23909,7 +22918,8 @@
     },
     "node_modules/get-uri/node_modules/fs-extra": {
       "version": "8.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -24094,7 +23104,8 @@
     },
     "node_modules/global-modules": {
       "version": "0.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==",
       "dependencies": {
         "global-prefix": "^0.1.4",
         "is-windows": "^0.2.0"
@@ -24105,14 +23116,16 @@
     },
     "node_modules/global-modules/node_modules/is-windows": {
       "version": "0.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/global-prefix": {
       "version": "0.1.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==",
       "dependencies": {
         "homedir-polyfill": "^1.0.0",
         "ini": "^1.3.4",
@@ -24125,7 +23138,8 @@
     },
     "node_modules/global-prefix/node_modules/is-windows": {
       "version": "0.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24385,7 +23399,8 @@
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dependencies": {
         "parse-passwd": "^1.0.0"
       },
@@ -24497,7 +23512,8 @@
     },
     "node_modules/http-link-header": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.1.tgz",
+      "integrity": "sha512-mW3N/rTYpCn99s1do0zx6nzFZSwLH9HGfUM4ZqLWJ16ylmYaC2v5eYGqrNTQlByx8AzUgGI+V/32gXPugs1+Sw==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -24643,7 +23659,8 @@
     },
     "node_modules/image-ssim": {
       "version": "0.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg=="
     },
     "node_modules/immutable": {
       "version": "4.3.0",
@@ -24829,14 +23846,17 @@
     },
     "node_modules/intl-messageformat": {
       "version": "4.4.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-4.4.0.tgz",
+      "integrity": "sha512-z+Bj2rS3LZSYU4+sNitdHrwnBhr0wO80ZJSW8EzKDBowwUe3Q/UsvgCGjrwa+HPzoGCLEb9HAjfJgo4j2Sac8w==",
       "dependencies": {
         "intl-messageformat-parser": "^1.8.1"
       }
     },
     "node_modules/intl-messageformat-parser": {
       "version": "1.8.1",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.8.1.tgz",
+      "integrity": "sha512-IMSCKVf0USrM/959vj3xac7s8f87sc+80Y/ipBzdKy4ifBv5Gsj2tZ41EAaURVg01QU71fYr77uA8Meh6kELbg==",
+      "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser"
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -24858,7 +23878,8 @@
     },
     "node_modules/irregular-plurals": {
       "version": "3.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+      "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
       "engines": {
         "node": ">=8"
       }
@@ -24954,7 +23975,8 @@
     },
     "node_modules/is-builtin-module": {
       "version": "3.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
       "dependencies": {
         "builtin-modules": "^3.3.0"
       },
@@ -25096,35 +24118,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container/node_modules/is-docker": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
       "dev": true,
@@ -25187,7 +24180,8 @@
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "engines": {
         "node": ">=8"
       }
@@ -25345,7 +24339,8 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -26079,21 +25074,26 @@
       }
     },
     "node_modules/jest-dev-server": {
-      "version": "6.2.0",
-      "license": "MIT",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-9.0.2.tgz",
+      "integrity": "sha512-Zc/JB0IlNNrpXkhBw+h86cGrde/Mey52KvF+FER2eyrtYJTHObOwW7Iarxm3rPyTKby5+3Y2QZtl8pRz/5GCxg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "cwd": "^0.10.0",
         "find-process": "^1.4.7",
         "prompts": "^2.4.2",
-        "spawnd": "^6.2.0",
+        "spawnd": "^9.0.2",
         "tree-kill": "^1.2.2",
-        "wait-on": "^6.0.1"
+        "wait-on": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/jest-dev-server/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -26106,7 +25106,8 @@
     },
     "node_modules/jest-dev-server/node_modules/chalk": {
       "version": "4.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -26120,7 +25121,8 @@
     },
     "node_modules/jest-dev-server/node_modules/color-convert": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -26130,18 +25132,21 @@
     },
     "node_modules/jest-dev-server/node_modules/color-name": {
       "version": "1.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/jest-dev-server/node_modules/has-flag": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/jest-dev-server/node_modules/supports-color": {
       "version": "7.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -27253,23 +26258,26 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.9.1",
-      "license": "BSD-3-Clause",
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.0.tgz",
+      "integrity": "sha512-HSLsmSmXz+PV9PYoi3p7cgIbj06WnEBNT28n+bbBNcPZXZFqCzzvGqpTBPujx/Z0nh1+KNQPDrNgdmQ8dq0qYw==",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.4",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/jpeg-js": {
       "version": "0.4.4",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
     },
     "node_modules/js-library-detector": {
       "version": "6.7.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.7.0.tgz",
+      "integrity": "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==",
       "engines": {
         "node": ">=12"
       }
@@ -27430,7 +26438,8 @@
     },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -27703,7 +26712,8 @@
     },
     "node_modules/lighthouse": {
       "version": "10.4.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-10.4.0.tgz",
+      "integrity": "sha512-XQWHEWkJ8YxSPsxttBJORy5+hQrzbvGkYfeP3fJjyYKioWkF2MXfFqNK4ZuV4jL8pBu7Z91qnQP6In0bq1yXww==",
       "dependencies": {
         "@sentry/node": "^6.17.4",
         "axe-core": "4.7.2",
@@ -27744,7 +26754,8 @@
     },
     "node_modules/lighthouse-logger": {
       "version": "1.4.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
       "dependencies": {
         "debug": "^2.6.9",
         "marky": "^1.2.2"
@@ -27752,40 +26763,47 @@
     },
     "node_modules/lighthouse-logger/node_modules/debug": {
       "version": "2.6.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/lighthouse-logger/node_modules/ms": {
       "version": "2.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/lighthouse-stack-packs": {
       "version": "1.11.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.11.0.tgz",
+      "integrity": "sha512-sRr0z1S/I26VffRLq9KJsKtLk856YrJlNGmcJmbLX8dFn3MuzVPUbstuChEhqnSxZb8TZmVfthuXuwhG9vRoSw=="
     },
     "node_modules/lighthouse/node_modules/axe-core": {
       "version": "4.7.2",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
+      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/lighthouse/node_modules/cross-fetch": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
     "node_modules/lighthouse/node_modules/devtools-protocol": {
       "version": "0.0.1155343",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1155343.tgz",
+      "integrity": "sha512-oD9vGBV2wTc7fAzAM6KC0chSgs234V8+qDEeK+mcbRj2UvcuA7lgBztGi/opj/iahcXD3BSj8Ymvib628yy9FA=="
     },
     "node_modules/lighthouse/node_modules/node-fetch": {
       "version": "2.7.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -27803,7 +26821,8 @@
     },
     "node_modules/lighthouse/node_modules/puppeteer-core": {
       "version": "20.9.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
+      "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
       "dependencies": {
         "@puppeteer/browsers": "1.4.6",
         "chromium-bidi": "0.4.16",
@@ -27826,11 +26845,13 @@
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
       "version": "0.0.1147663",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
+      "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ=="
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
       "version": "8.13.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -27849,7 +26870,8 @@
     },
     "node_modules/lighthouse/node_modules/ws": {
       "version": "7.5.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -27868,7 +26890,8 @@
     },
     "node_modules/lighthouse/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
       }
@@ -28075,7 +27098,8 @@
     },
     "node_modules/lookup-closest-locale": {
       "version": "6.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
+      "integrity": "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -28096,7 +27120,8 @@
     },
     "node_modules/lru_map": {
       "version": "0.3.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "node_modules/lru-cache": {
       "version": "4.1.5",
@@ -28328,7 +27353,8 @@
     },
     "node_modules/marky": {
       "version": "1.2.5",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
+      "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q=="
     },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
@@ -28463,7 +27489,8 @@
     },
     "node_modules/metaviewport-parser": {
       "version": "0.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
+      "integrity": "sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ=="
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -28656,7 +27683,8 @@
     },
     "node_modules/mitt": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "node_modules/mixin-object": {
       "version": "2.0.1",
@@ -28794,7 +27822,8 @@
     },
     "node_modules/netmask": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -28951,7 +27980,8 @@
     },
     "node_modules/npm-package-json-lint": {
       "version": "6.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-6.4.0.tgz",
+      "integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
       "dependencies": {
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",
@@ -28981,7 +28011,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -28994,18 +28025,21 @@
     },
     "node_modules/npm-package-json-lint/node_modules/argparse": {
       "version": "2.0.1",
-      "license": "Python-2.0"
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/npm-package-json-lint/node_modules/builtins": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
       "dependencies": {
         "semver": "^7.0.0"
       }
     },
     "node_modules/npm-package-json-lint/node_modules/chalk": {
       "version": "4.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -29019,7 +28053,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/color-convert": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -29029,11 +28064,13 @@
     },
     "node_modules/npm-package-json-lint/node_modules/color-name": {
       "version": "1.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/npm-package-json-lint/node_modules/cosmiconfig": {
       "version": "8.3.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -29057,14 +28094,16 @@
     },
     "node_modules/npm-package-json-lint/node_modules/has-flag": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/npm-package-json-lint/node_modules/hosted-git-info": {
       "version": "4.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -29074,7 +28113,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/is-plain-obj": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
       "engines": {
         "node": ">=10"
       },
@@ -29084,7 +28124,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/js-yaml": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -29093,12 +28134,14 @@
       }
     },
     "node_modules/npm-package-json-lint/node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "license": "MIT"
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
     },
     "node_modules/npm-package-json-lint/node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -29108,7 +28151,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/meow": {
       "version": "9.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
       "dependencies": {
         "@types/minimist": "^1.2.0",
         "camelcase-keys": "^6.2.2",
@@ -29132,7 +28176,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/meow/node_modules/type-fest": {
       "version": "0.18.1",
-      "license": "(MIT OR CC0-1.0)",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
       "engines": {
         "node": ">=10"
       },
@@ -29142,7 +28187,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/normalize-package-data": {
       "version": "3.0.3",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "dependencies": {
         "hosted-git-info": "^4.0.1",
         "is-core-module": "^2.5.0",
@@ -29155,7 +28201,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/semver": {
       "version": "7.5.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -29168,7 +28215,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/supports-color": {
       "version": "7.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -29178,7 +28226,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/type-fest": {
       "version": "3.13.1",
-      "license": "(MIT OR CC0-1.0)",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
       "engines": {
         "node": ">=14.16"
       },
@@ -29188,7 +28237,8 @@
     },
     "node_modules/npm-package-json-lint/node_modules/validate-npm-package-name": {
       "version": "5.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
+      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
       "dependencies": {
         "builtins": "^5.0.0"
       },
@@ -29198,11 +28248,13 @@
     },
     "node_modules/npm-package-json-lint/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/npm-package-json-lint/node_modules/yargs-parser": {
       "version": "20.2.9",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
       }
@@ -29549,7 +28601,8 @@
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29627,7 +28680,8 @@
     },
     "node_modules/pac-proxy-agent": {
       "version": "7.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.0.2",
@@ -29644,7 +28698,8 @@
     },
     "node_modules/pac-proxy-agent/node_modules/agent-base": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -29654,7 +28709,8 @@
     },
     "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -29665,7 +28721,8 @@
     },
     "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
       "version": "7.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -29676,7 +28733,8 @@
     },
     "node_modules/pac-resolver": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
+      "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
       "dependencies": {
         "degenerator": "^5.0.0",
         "ip": "^1.1.8",
@@ -29688,7 +28746,8 @@
     },
     "node_modules/pac-resolver/node_modules/ip": {
       "version": "1.1.8",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
+      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
     },
     "node_modules/pako": {
       "version": "0.2.9",
@@ -29719,7 +28778,9 @@
       }
     },
     "node_modules/parse-cache-control": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -29739,7 +28800,8 @@
     },
     "node_modules/parse-passwd": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29961,11 +29023,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.39.0",
-      "license": "Apache-2.0",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.1.tgz",
+      "integrity": "sha512-gdZAWG97oUnbBdRL3GuBvX3nDDmUOuqzV/D24dytqlKt+eI5KbwusluZRGljx1YoJKZ2NRPaeWiFTeGZO7SosQ==",
       "peer": true,
       "dependencies": {
-        "playwright-core": "1.39.0"
+        "playwright-core": "1.41.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -29978,18 +29041,20 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.32.0",
-      "license": "Apache-2.0",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "bin": {
-        "playwright": "cli.js"
+        "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/playwright/node_modules/playwright-core": {
-      "version": "1.39.0",
-      "license": "Apache-2.0",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.1.tgz",
+      "integrity": "sha512-/KPO5DzXSMlxSX77wy+HihKGOunh3hqndhqeo/nMxfigiKzogn8kfL0ZBDu0L1RKgan5XHCPmn6zXd2NUJgjhg==",
       "peer": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -30000,7 +29065,8 @@
     },
     "node_modules/plur": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
       "dependencies": {
         "irregular-plurals": "^3.2.0"
       },
@@ -30720,7 +29786,8 @@
     },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "dependencies": {
         "fast-diff": "^1.1.2"
       },
@@ -30832,7 +29899,8 @@
     },
     "node_modules/proxy-agent": {
       "version": "6.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
+      "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -30849,7 +29917,8 @@
     },
     "node_modules/proxy-agent/node_modules/agent-base": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -30859,7 +29928,8 @@
     },
     "node_modules/proxy-agent/node_modules/http-proxy-agent": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -30870,7 +29940,8 @@
     },
     "node_modules/proxy-agent/node_modules/https-proxy-agent": {
       "version": "7.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -30881,7 +29952,8 @@
     },
     "node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "7.18.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
         "node": ">=12"
       }
@@ -30896,7 +29968,8 @@
     },
     "node_modules/ps-list": {
       "version": "8.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-8.1.1.tgz",
+      "integrity": "sha512-OPS9kEJYVmiO48u/B9qneqhkMvgCxT+Tm28VCEJpheTpl8cJ0ffZRRNgS5mrQRTrX5yRTpaJ+hRDeefXYmmorQ==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -31018,7 +30091,8 @@
     },
     "node_modules/queue-tick": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -31641,7 +30715,8 @@
     },
     "node_modules/requireindex": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "engines": {
         "node": ">=0.10.5"
       }
@@ -31684,7 +30759,8 @@
     },
     "node_modules/resolve-dir": {
       "version": "0.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "integrity": "sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==",
       "dependencies": {
         "expand-tilde": "^1.2.2",
         "global-modules": "^0.2.3"
@@ -31789,15 +30865,17 @@
     },
     "node_modules/robots-parser": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/rollup": {
-      "version": "3.24.0",
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "devOptional": true,
-      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -31807,99 +30885,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-applescript": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/run-applescript/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/run-applescript/node_modules/execa": {
-      "version": "5.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/run-applescript/node_modules/get-stream": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/run-applescript/node_modules/human-signals": {
-      "version": "2.1.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/run-applescript/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/run-applescript/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/run-applescript/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/run-async": {
@@ -32650,7 +31635,8 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -32780,7 +31766,8 @@
     },
     "node_modules/socks": {
       "version": "2.7.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "dependencies": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -32792,7 +31779,8 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "8.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+      "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -32804,7 +31792,8 @@
     },
     "node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -32890,12 +31879,26 @@
       }
     },
     "node_modules/spawnd": {
-      "version": "6.2.0",
-      "license": "MIT",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-9.0.2.tgz",
+      "integrity": "sha512-nl8DVHEDQ57IcKakzpjanspVChkMpGLuVwMR/eOn9cXE55Qr6luD2Kn06sA0ootRMdgrU4tInN6lA6ohTNvysw==",
       "dependencies": {
-        "exit": "^0.1.2",
-        "signal-exit": "^3.0.7",
+        "signal-exit": "^4.1.0",
         "tree-kill": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/spawnd/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/spawndamnit": {
@@ -32959,7 +31962,8 @@
     },
     "node_modules/speedline-core": {
       "version": "1.4.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz",
+      "integrity": "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==",
       "dependencies": {
         "@types/node": "*",
         "image-ssim": "^0.2.0",
@@ -33053,8 +32057,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.2",
-      "license": "MIT",
+      "version": "2.15.6",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
       "dependencies": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
@@ -33350,14 +32355,16 @@
     },
     "node_modules/stylelint-config-recommended": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
+      "integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
       "peerDependencies": {
         "stylelint": "^14.0.0"
       }
     },
     "node_modules/stylelint-config-recommended-scss": {
       "version": "5.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz",
+      "integrity": "sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==",
       "dependencies": {
         "postcss-scss": "^4.0.2",
         "stylelint-config-recommended": "^6.0.0",
@@ -33625,11 +32632,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/synckit": {
-      "version": "0.8.5",
-      "license": "MIT",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
+      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
       "dependencies": {
-        "@pkgr/utils": "^2.3.1",
-        "tslib": "^2.5.0"
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -34031,7 +33039,8 @@
     },
     "node_modules/third-party-web": {
       "version": "0.23.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.23.4.tgz",
+      "integrity": "sha512-kwYnSZRhEvv0SBW2fp8SBBKRglMoBjV8xz6C31m0ewqOtknB5UL+Ihg+M81hyFY5ldkZuGWPb+e4GVDkzf/gYg=="
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -34090,16 +33099,6 @@
       "version": "1.3.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/titleize": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -34177,7 +33176,8 @@
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "bin": {
         "tree-kill": "cli.js"
       }
@@ -34579,7 +33579,8 @@
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -34592,7 +33593,8 @@
     },
     "node_modules/tsutils/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tty-table": {
       "version": "4.2.1",
@@ -34813,7 +33815,8 @@
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -34983,6 +33986,7 @@
     },
     "node_modules/untildify": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -35276,14 +34280,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.3.9",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "devOptional": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "esbuild": "^0.17.5",
-        "postcss": "^8.4.23",
-        "rollup": "^3.21.0"
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -35291,12 +34296,16 @@
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
         "@types/node": ">= 14",
         "less": "*",
+        "lightningcss": "^1.21.0",
         "sass": "*",
         "stylus": "*",
         "sugarss": "*",
@@ -35307,6 +34316,9 @@
           "optional": true
         },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -35334,25 +34346,27 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "6.0.1",
-      "license": "MIT",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
       "dependencies": {
-        "axios": "^0.25.0",
-        "joi": "^17.6.0",
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.5",
-        "rxjs": "^7.5.4"
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       },
       "bin": {
         "wait-on": "bin/wait-on"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/wait-on/node_modules/rxjs": {
-      "version": "7.8.0",
-      "license": "Apache-2.0",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -35389,6 +34403,11 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.1.tgz",
+      "integrity": "sha512-xQ9lvIpfLxUj0eSmT79ZjRoU5wIRfIr7pNukL7ZE4EcWZSmfZQqOlhuAGfkVa3EFmzPHZhWhXfm2i5ys+THVPg=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -36240,7 +35259,8 @@
     },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "engines": {
         "node": ">=8"
       }
@@ -36833,9 +35853,9 @@
         "react-dom": "18.2.0"
       },
       "devDependencies": {
-        "@alleyinteractive/eslint-config": "^0.1.0",
-        "@alleyinteractive/stylelint-config": "^0.0.2",
-        "@alleyinteractive/tsconfig": "^0.1.0",
+        "@alleyinteractive/eslint-config": "*",
+        "@alleyinteractive/stylelint-config": "*",
+        "@alleyinteractive/tsconfig": "*",
         "@babel/preset-env": "^7.23.2",
         "@types/wordpress__edit-post": "^7.0.1",
         "@types/wordpress__plugins": "^3.0.0",
@@ -39016,9 +38036,11 @@
       "version": "0.3.0"
     },
     "@es-joy/jsdoccomment": {
-      "version": "0.40.1",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
+      "integrity": "sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==",
       "requires": {
-        "comment-parser": "1.4.0",
+        "comment-parser": "1.4.1",
         "esquery": "^1.5.0",
         "jsdoc-type-pratt-parser": "~4.0.0"
       }
@@ -39045,10 +38067,11 @@
       "optional": true
     },
     "@esbuild/darwin-arm64": {
-      "version": "0.17.15",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@esbuild/darwin-x64": {
       "version": "0.18.20",
@@ -39254,10 +38277,14 @@
       "version": "0.1.1"
     },
     "@hapi/hoek": {
-      "version": "9.3.0"
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "@hapi/topo": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -39895,59 +38922,18 @@
       "version": "0.11.0",
       "optional": true
     },
-    "@pkgr/utils": {
-      "version": "2.4.2",
-      "requires": {
-        "cross-spawn": "^7.0.3",
-        "fast-glob": "^3.3.0",
-        "is-glob": "^4.0.3",
-        "open": "^9.1.0",
-        "picocolors": "^1.0.0",
-        "tslib": "^2.6.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.3",
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "define-lazy-prop": {
-          "version": "3.0.0"
-        },
-        "open": {
-          "version": "9.1.0",
-          "requires": {
-            "default-browser": "^4.0.0",
-            "define-lazy-prop": "^3.0.0",
-            "is-inside-container": "^1.0.0",
-            "is-wsl": "^2.2.0"
-          }
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0"
-        },
-        "which": {
-          "version": "2.0.2",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
+    "@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA=="
     },
     "@playwright/test": {
-      "version": "1.39.0",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.1.tgz",
+      "integrity": "sha512-9g8EWTjiQ9yFBXc6HjCWe41msLpxEX0KhmfmPl9RPLJdfzL4F0lg2BdJ91O9azFdl11y1pmpwdjBiSxvqc+btw==",
       "peer": true,
       "requires": {
-        "playwright": "1.39.0"
+        "playwright": "1.41.1"
       }
     },
     "@polka/url": {
@@ -39967,6 +38953,8 @@
     },
     "@puppeteer/browsers": {
       "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
+      "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -39979,6 +38967,8 @@
       "dependencies": {
         "tar-fs": {
           "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+          "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
           "requires": {
             "mkdirp-classic": "^0.5.2",
             "pump": "^3.0.0",
@@ -39986,7 +38976,9 @@
           }
         },
         "tar-stream": {
-          "version": "3.1.6",
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
           "requires": {
             "b4a": "^1.6.4",
             "fast-fifo": "^1.2.0",
@@ -40779,6 +39771,8 @@
     },
     "@sentry/core": {
       "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
+      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
       "requires": {
         "@sentry/hub": "6.19.7",
         "@sentry/minimal": "6.19.7",
@@ -40788,12 +39782,16 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sentry/hub": {
       "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
+      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
       "requires": {
         "@sentry/types": "6.19.7",
         "@sentry/utils": "6.19.7",
@@ -40801,12 +39799,16 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sentry/minimal": {
       "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
+      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
       "requires": {
         "@sentry/hub": "6.19.7",
         "@sentry/types": "6.19.7",
@@ -40814,12 +39816,16 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sentry/node": {
       "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
+      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
       "requires": {
         "@sentry/core": "6.19.7",
         "@sentry/hub": "6.19.7",
@@ -40832,39 +39838,55 @@
       },
       "dependencies": {
         "cookie": {
-          "version": "0.4.2"
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
         },
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sentry/types": {
-      "version": "6.19.7"
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
+      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg=="
     },
     "@sentry/utils": {
       "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
+      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
       "requires": {
         "@sentry/types": "6.19.7",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sideway/address": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
     },
     "@sideway/formula": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "@sideway/pinpoint": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8"
@@ -41053,11 +40075,6 @@
         "ts-dedent": "^2.0.0"
       },
       "dependencies": {
-        "@esbuild/darwin-arm64": {
-          "version": "0.18.20",
-          "dev": true,
-          "optional": true
-        },
         "@storybook/channels": {
           "version": "7.5.3",
           "dev": true,
@@ -41179,34 +40196,6 @@
         "color-name": {
           "version": "1.1.4",
           "dev": true
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
         },
         "find-up": {
           "version": "5.0.0",
@@ -41434,11 +40423,6 @@
         "ts-dedent": "^2.0.0"
       },
       "dependencies": {
-        "@esbuild/darwin-arm64": {
-          "version": "0.18.20",
-          "dev": true,
-          "optional": true
-        },
         "@storybook/channels": {
           "version": "7.5.3",
           "dev": true,
@@ -41560,34 +40544,6 @@
         "color-name": {
           "version": "1.1.4",
           "dev": true
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
         },
         "find-up": {
           "version": "5.0.0",
@@ -42273,11 +41229,6 @@
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
-        "@esbuild/darwin-arm64": {
-          "version": "0.18.20",
-          "dev": true,
-          "optional": true
-        },
         "@storybook/channels": {
           "version": "7.5.3",
           "dev": true,
@@ -42412,34 +41363,6 @@
           "version": "1.1.4",
           "dev": true
         },
-        "esbuild": {
-          "version": "0.18.20",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
-        },
         "find-up": {
           "version": "5.0.0",
           "dev": true,
@@ -42532,11 +41455,6 @@
         "util": "^0.12.4"
       },
       "dependencies": {
-        "@esbuild/darwin-arm64": {
-          "version": "0.18.20",
-          "dev": true,
-          "optional": true
-        },
         "@storybook/channels": {
           "version": "7.5.1",
           "dev": true,
@@ -42636,34 +41554,6 @@
           "version": "1.1.4",
           "dev": true
         },
-        "esbuild": {
-          "version": "0.18.20",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
-        },
         "find-up": {
           "version": "5.0.0",
           "dev": true,
@@ -42758,13 +41648,6 @@
         "rollup": "^2.25.0 || ^3.3.0"
       },
       "dependencies": {
-        "@esbuild/darwin-arm64": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-          "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-          "dev": true,
-          "optional": true
-        },
         "@jridgewell/sourcemap-codec": {
           "version": "1.4.15",
           "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
@@ -42916,36 +41799,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-          "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
         },
         "find-up": {
           "version": "5.0.0",
@@ -43105,11 +41958,6 @@
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
-        "@esbuild/darwin-arm64": {
-          "version": "0.18.20",
-          "dev": true,
-          "optional": true
-        },
         "@storybook/channels": {
           "version": "7.5.1",
           "dev": true,
@@ -43239,34 +42087,6 @@
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
-          }
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
           }
         },
         "execa": {
@@ -43777,11 +42597,6 @@
         "ts-dedent": "^2.0.0"
       },
       "dependencies": {
-        "@esbuild/darwin-arm64": {
-          "version": "0.18.20",
-          "dev": true,
-          "optional": true
-        },
         "@types/node": {
           "version": "16.18.58",
           "dev": true
@@ -43811,34 +42626,6 @@
         "color-name": {
           "version": "1.1.4",
           "dev": true
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
         },
         "find-up": {
           "version": "5.0.0",
@@ -43964,11 +42751,6 @@
         "ws": "^8.2.3"
       },
       "dependencies": {
-        "@esbuild/darwin-arm64": {
-          "version": "0.18.20",
-          "dev": true,
-          "optional": true
-        },
         "@storybook/channels": {
           "version": "7.5.1",
           "dev": true,
@@ -44102,34 +42884,6 @@
         "color-name": {
           "version": "1.1.4",
           "dev": true
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
         },
         "find-up": {
           "version": "5.0.0",
@@ -44353,13 +43107,6 @@
         "lodash": "^4.17.21"
       },
       "dependencies": {
-        "@esbuild/darwin-arm64": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-          "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-          "dev": true,
-          "optional": true
-        },
         "@storybook/channels": {
           "version": "7.6.1",
           "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.1.tgz",
@@ -44505,36 +43252,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-          "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
         },
         "find-up": {
           "version": "5.0.0",
@@ -44945,11 +43662,6 @@
         "read-pkg-up": "^7.0.1"
       },
       "dependencies": {
-        "@esbuild/darwin-arm64": {
-          "version": "0.18.20",
-          "dev": true,
-          "optional": true
-        },
         "@storybook/channels": {
           "version": "7.5.1",
           "dev": true,
@@ -45063,34 +43775,6 @@
         "color-name": {
           "version": "1.1.4",
           "dev": true
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "dev": true,
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
         },
         "find-up": {
           "version": "5.0.0",
@@ -45422,7 +44106,9 @@
       "version": "2.0.0"
     },
     "@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0"
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
     "@trysound/sax": {
       "version": "0.2.0"
@@ -46309,6 +44995,8 @@
     },
     "@typescript-eslint/utils": {
       "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
@@ -46322,16 +45010,22 @@
       "dependencies": {
         "@typescript-eslint/scope-manager": {
           "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+          "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
           "requires": {
             "@typescript-eslint/types": "5.62.0",
             "@typescript-eslint/visitor-keys": "5.62.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.62.0"
+          "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+          "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ=="
         },
         "@typescript-eslint/typescript-estree": {
           "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+          "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
           "requires": {
             "@typescript-eslint/types": "5.62.0",
             "@typescript-eslint/visitor-keys": "5.62.0",
@@ -46344,28 +45038,38 @@
         },
         "@typescript-eslint/visitor-keys": {
           "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+          "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
           "requires": {
             "@typescript-eslint/types": "5.62.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
         "eslint-visitor-keys": {
-          "version": "3.4.3"
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
         },
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -46530,11 +45234,13 @@
       }
     },
     "@wordpress/api-fetch": {
-      "version": "6.42.0",
+      "version": "6.46.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.46.0.tgz",
+      "integrity": "sha512-SimHPw57N8LyZpQB6dK5xq1Kn1WtqP/K27GjGwvxvkb+8xbVv0TI67AF9adsN4sZbOHIZJQwqvCTSGKhNttAvQ==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.45.0",
-        "@wordpress/url": "^3.46.0"
+        "@wordpress/i18n": "^4.49.0",
+        "@wordpress/url": "^3.50.0"
       }
     },
     "@wordpress/autop": {
@@ -46544,11 +45250,15 @@
       }
     },
     "@wordpress/babel-plugin-import-jsx-pragma": {
-      "version": "4.28.0",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.32.0.tgz",
+      "integrity": "sha512-ie6p5VpUxTNMPQrHdCYEPddTzmDeFTQjFi3qq17set9WbRAMaOZ8jqQhSxms0NJi8Xa6wZM9TR2ZABAlg+FTeA==",
       "requires": {}
     },
     "@wordpress/babel-preset-default": {
-      "version": "7.29.0",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.33.0.tgz",
+      "integrity": "sha512-/OonEa67xJdIn0ADWEd7AJtLhIGlYALKyc17RxTmI2Ojs0zLIQNbgAv1D/cuVguo0UKK9zsMZ9MBkhSKLF9A9Q==",
       "requires": {
         "@babel/core": "^7.16.0",
         "@babel/plugin-transform-react-jsx": "^7.16.0",
@@ -46556,16 +45266,18 @@
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
         "@babel/runtime": "^7.16.0",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^4.28.0",
-        "@wordpress/browserslist-config": "^5.28.0",
-        "@wordpress/warning": "^2.45.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^4.32.0",
+        "@wordpress/browserslist-config": "^5.32.0",
+        "@wordpress/warning": "^2.49.0",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.2.0"
       }
     },
     "@wordpress/base-styles": {
-      "version": "4.36.0"
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.40.0.tgz",
+      "integrity": "sha512-A+HiyES4YjfbFhJAGrhCLB3QWomgWZR9wkgG7K9l6DD70/9Vd7t+go7jI1HJ1c9qGfBV0rmdQf/qNn89Aai1cg=="
     },
     "@wordpress/blob": {
       "version": "3.45.0",
@@ -46888,7 +45600,9 @@
       }
     },
     "@wordpress/browserslist-config": {
-      "version": "5.28.0"
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.32.0.tgz",
+      "integrity": "sha512-LrL4Zg/abXYfVwwbx1caugz4J1GUL+6WNqVF1MZQVDm6CHdlpTEQOvvr/KEi9mN1UY2YoTlxZtUxzvNRTo2Fsg=="
     },
     "@wordpress/commands": {
       "version": "0.16.0",
@@ -47235,7 +45949,9 @@
       }
     },
     "@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "4.28.0",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.31.0.tgz",
+      "integrity": "sha512-Xpm8EEhi6e8GL1juYh/70AFbcE/ZVXJ3p47KMkkEsn5t+hG9QHjKe2lTj98v2r3rB+ampoK+whdV1w6gItXYpw==",
       "requires": {
         "json2php": "^0.0.7",
         "webpack-sources": "^3.2.2"
@@ -47262,20 +45978,25 @@
       }
     },
     "@wordpress/e2e-test-utils-playwright": {
-      "version": "0.13.0",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.16.0.tgz",
+      "integrity": "sha512-CktRj5/Cc/pAvTHXIAPIMrmmnb0VjtXbTGSjYG6pW/JI2YAmpwY2yBA+DlHJjqOIpcjDDj+sSsJomRSxT2chwQ==",
       "requires": {
-        "@wordpress/api-fetch": "^6.42.0",
-        "@wordpress/keycodes": "^3.45.0",
-        "@wordpress/url": "^3.46.0",
+        "@wordpress/api-fetch": "^6.45.0",
+        "@wordpress/keycodes": "^3.48.0",
+        "@wordpress/url": "^3.49.0",
         "change-case": "^4.1.2",
         "form-data": "^4.0.0",
         "get-port": "^5.1.1",
         "lighthouse": "^10.4.0",
-        "mime": "^3.0.0"
+        "mime": "^3.0.0",
+        "web-vitals": "^3.5.0"
       },
       "dependencies": {
         "form-data": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -47283,7 +46004,9 @@
           }
         },
         "mime": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
         }
       }
     },
@@ -47564,7 +46287,9 @@
       }
     },
     "@wordpress/hooks": {
-      "version": "3.45.0",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.49.0.tgz",
+      "integrity": "sha512-GH546Jg8u/rw9I3fsvAhidwt8rUFNmkdXGByIPGsN3R6y+QwWMXPzsnoYdFmFOmDK9gOGCRDe5bXHikoWnaiKA==",
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
@@ -47576,10 +46301,12 @@
       }
     },
     "@wordpress/i18n": {
-      "version": "4.45.0",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.49.0.tgz",
+      "integrity": "sha512-8aZmmRfOHzS/3pMWg+4f6QlPci0wK5V+PDllAwtwFFrXgc0pmk8VXu7Quajh1tiVoIQDCZpK6h1sqa+qrCLpZg==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.45.0",
+        "@wordpress/hooks": "^3.49.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "sprintf-js": "^1.1.1",
@@ -47722,16 +46449,20 @@
       }
     },
     "@wordpress/jest-console": {
-      "version": "7.16.0",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.20.0.tgz",
+      "integrity": "sha512-EXexYwBLaJSpSCUwpQeSqjJ9G7KDkzH+oCfiZp4ZYuemmCaJFOn8/HOLwfLU0o7i0bfYFAjt8lSVCr5HiYY0AA==",
       "requires": {
         "@babel/runtime": "^7.16.0",
         "jest-matcher-utils": "^29.6.2"
       }
     },
     "@wordpress/jest-preset-default": {
-      "version": "11.16.0",
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.20.0.tgz",
+      "integrity": "sha512-3x2ua/rc0540zfLOrHbfdrEOwS5xWPbX5/f2LUyM2T6zzmhXrnqG2WFdhftFFLAUhC8cbxuy1WNnrzgjUxGeDQ==",
       "requires": {
-        "@wordpress/jest-console": "^7.16.0",
+        "@wordpress/jest-console": "^7.20.0",
         "babel-jest": "^29.6.2"
       }
     },
@@ -47746,11 +46477,12 @@
       }
     },
     "@wordpress/keycodes": {
-      "version": "3.45.0",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.49.0.tgz",
+      "integrity": "sha512-Hg+kUTV/ti+CyG4+D3dmRFMmrE45E2QEv7ZKaeIf+t1wlafekLSDwIpdF7e68HxEMmZSzHmLm7bHqQTNjxAoKQ==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.45.0",
-        "change-case": "^4.1.2"
+        "@wordpress/i18n": "^4.49.0"
       }
     },
     "@wordpress/lazy-import": {
@@ -47797,7 +46529,9 @@
       }
     },
     "@wordpress/npm-package-json-lint-config": {
-      "version": "4.30.0",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.34.0.tgz",
+      "integrity": "sha512-mknDw+d5HIfx/1DyrhkbLJNu8XsmUEjc1SsYSgF2XCP20/khpO7YOi0LWn9uQ2QXWZrlhMc7JKSSOcTs0aLphQ==",
       "requires": {}
     },
     "@wordpress/patterns": {
@@ -47915,9 +46649,11 @@
       }
     },
     "@wordpress/postcss-plugins-preset": {
-      "version": "4.29.0",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.33.0.tgz",
+      "integrity": "sha512-RqKNf8XQTdae0cXO11l6mBw+A3IOEO9dd4sD70g15e4IltrbwuxqwOT5k9muNteUszTCOQKgWgD8gp1KM2/lvQ==",
       "requires": {
-        "@wordpress/base-styles": "^4.36.0",
+        "@wordpress/base-styles": "^4.40.0",
         "autoprefixer": "^10.2.5"
       }
     },
@@ -48177,21 +46913,23 @@
       }
     },
     "@wordpress/scripts": {
-      "version": "26.16.0",
+      "version": "26.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-26.19.0.tgz",
+      "integrity": "sha512-m3QYlgpWRfIqCfU4jWKwGeA12Qkt6d9CMewEIxIBGVlEGd/sL5rU1fM7LKNBEbSPQpaOTWJApNGWPcW75Fwp+w==",
       "requires": {
         "@babel/core": "^7.16.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^7.29.0",
-        "@wordpress/browserslist-config": "^5.28.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^4.28.0",
-        "@wordpress/e2e-test-utils-playwright": "^0.13.0",
-        "@wordpress/eslint-plugin": "^17.2.0",
-        "@wordpress/jest-preset-default": "^11.16.0",
-        "@wordpress/npm-package-json-lint-config": "^4.30.0",
-        "@wordpress/postcss-plugins-preset": "^4.29.0",
-        "@wordpress/prettier-config": "^3.2.0",
-        "@wordpress/stylelint-config": "^21.28.0",
+        "@wordpress/babel-preset-default": "^7.32.0",
+        "@wordpress/browserslist-config": "^5.31.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^4.31.0",
+        "@wordpress/e2e-test-utils-playwright": "^0.16.0",
+        "@wordpress/eslint-plugin": "^17.5.0",
+        "@wordpress/jest-preset-default": "^11.19.0",
+        "@wordpress/npm-package-json-lint-config": "^4.33.0",
+        "@wordpress/postcss-plugins-preset": "^4.32.0",
+        "@wordpress/prettier-config": "^3.5.0",
+        "@wordpress/stylelint-config": "^21.31.0",
         "adm-zip": "^0.5.9",
         "babel-jest": "^29.6.2",
         "babel-loader": "^8.2.3",
@@ -48210,7 +46948,7 @@
         "fast-glob": "^3.2.7",
         "filenamify": "^4.2.0",
         "jest": "^29.6.2",
-        "jest-dev-server": "^6.0.2",
+        "jest-dev-server": "^9.0.1",
         "jest-environment-jsdom": "^29.6.2",
         "jest-environment-node": "^29.6.2",
         "markdownlint-cli": "^0.31.1",
@@ -48219,7 +46957,7 @@
         "minimist": "^1.2.0",
         "npm-package-json-lint": "^6.4.0",
         "npm-packlist": "^3.0.0",
-        "playwright-core": "1.32.0",
+        "playwright-core": "1.39.0",
         "postcss": "^8.4.5",
         "postcss-loader": "^6.2.1",
         "prettier": "npm:wp-prettier@3.0.3",
@@ -48284,13 +47022,15 @@
           }
         },
         "@wordpress/eslint-plugin": {
-          "version": "17.2.0",
+          "version": "17.6.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-17.6.0.tgz",
+          "integrity": "sha512-piANQS5eaSPmpzPXdNZdXbKcHjAyXbuHeUd9ctVA+6sOMVay70+ICQj7Isu4o61Wv43KtxugQoa2PSBqVtrRKA==",
           "requires": {
             "@babel/eslint-parser": "^7.16.0",
             "@typescript-eslint/eslint-plugin": "^6.4.1",
             "@typescript-eslint/parser": "^6.4.1",
-            "@wordpress/babel-preset-default": "^7.29.0",
-            "@wordpress/prettier-config": "^3.2.0",
+            "@wordpress/babel-preset-default": "^7.33.0",
+            "@wordpress/prettier-config": "^3.6.0",
             "cosmiconfig": "^7.0.0",
             "eslint-config-prettier": "^8.3.0",
             "eslint-plugin-import": "^2.25.2",
@@ -48306,7 +47046,9 @@
           }
         },
         "@wordpress/prettier-config": {
-          "version": "3.2.0",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.6.0.tgz",
+          "integrity": "sha512-51GuCeeEGOi4qsMpzGFBmKbqEUKLqWj3eZDIwATymUaHsJPx9oT93dlIP97MqKIaWjxlhxCMt5RjxcCNT7Pckw==",
           "requires": {}
         },
         "ansi-styles": {
@@ -48388,10 +47130,12 @@
           }
         },
         "eslint-plugin-prettier": {
-          "version": "5.0.1",
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
+          "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
           "requires": {
             "prettier-linter-helpers": "^1.0.0",
-            "synckit": "^0.8.5"
+            "synckit": "^0.8.6"
           }
         },
         "find-up": {
@@ -48408,13 +47152,17 @@
           }
         },
         "globals": {
-          "version": "13.23.0",
+          "version": "13.24.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+          "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
           "requires": {
             "type-fest": "^0.20.2"
           },
           "dependencies": {
             "type-fest": {
-              "version": "0.20.2"
+              "version": "0.20.2",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+              "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
             }
           }
         },
@@ -48479,7 +47227,9 @@
           }
         },
         "prettier": {
-          "version": "npm:wp-prettier@3.0.3"
+          "version": "npm:wp-prettier@3.0.3",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
+          "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA=="
         },
         "sass-loader": {
           "version": "12.6.0",
@@ -48634,7 +47384,9 @@
       }
     },
     "@wordpress/stylelint-config": {
-      "version": "21.28.0",
+      "version": "21.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.32.0.tgz",
+      "integrity": "sha512-cmrzU55alv+OZu1fXBC2eZGgJIUwyD47TSDDP7l0o9yF6D/w0am7FxC9ungk/S2uK1oatN05nIPsFSTkuHQSzg==",
       "requires": {
         "stylelint-config-recommended": "^6.0.0",
         "stylelint-config-recommended-scss": "^5.0.2"
@@ -48669,7 +47421,9 @@
       }
     },
     "@wordpress/url": {
-      "version": "3.46.0",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.50.0.tgz",
+      "integrity": "sha512-+YQzsPim5Zx55o/y9urtd0CKANUgwqZSdUNjDWYZ/1CWxtLLzPgQJOabtl79hG2yjrKvjDe9PrDPff18bCmG5A==",
       "requires": {
         "@babel/runtime": "^7.16.0",
         "remove-accents": "^0.5.0"
@@ -48690,7 +47444,9 @@
       }
     },
     "@wordpress/warning": {
-      "version": "2.45.0"
+      "version": "2.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.49.0.tgz",
+      "integrity": "sha512-W2Nj9Nj0o2udPLf8jfGijRff3lzQgPOiLZcN4LFUPT6yyb9MxvNIg7ZVTBJL2TB78+KQKGrIH4ERjV5WyDRoEQ=="
     },
     "@wordpress/widgets": {
       "version": "3.22.0",
@@ -48910,6 +47666,8 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
       "requires": {}
     },
     "ajv-formats": {
@@ -48940,9 +47698,9 @@
       "version": "file:plugin",
       "requires": {
         "@alleyinteractive/block-editor-tools": "*",
-        "@alleyinteractive/eslint-config": "^0.1.0",
-        "@alleyinteractive/stylelint-config": "^0.0.2",
-        "@alleyinteractive/tsconfig": "^0.1.0",
+        "@alleyinteractive/eslint-config": "*",
+        "@alleyinteractive/stylelint-config": "*",
+        "@alleyinteractive/tsconfig": "*",
         "@babel/preset-env": "^7.23.2",
         "@types/jest": "^29.5.5",
         "@types/wordpress__block-editor": "^7.0.0",
@@ -49037,7 +47795,9 @@
       "dev": true
     },
     "are-docs-informative": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig=="
     },
     "arg": {
       "version": "4.1.3",
@@ -49167,6 +47927,14 @@
         "util": "^0.12.5"
       }
     },
+    "ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "requires": {
+        "tslib": "^2.0.1"
+      }
+    },
     "ast-types-flow": {
       "version": "0.0.8"
     },
@@ -49211,9 +47979,25 @@
       "version": "4.7.0"
     },
     "axios": {
-      "version": "0.25.0",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "requires": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "axobject-query": {
@@ -49223,7 +48007,9 @@
       }
     },
     "b4a": {
-      "version": "1.6.4"
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
     },
     "babel-core": {
       "version": "7.0.0-bridge.0",
@@ -49463,7 +48249,9 @@
       "version": "1.5.1"
     },
     "basic-ftp": {
-      "version": "5.0.3"
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
+      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA=="
     },
     "batch": {
       "version": "0.6.1"
@@ -49483,7 +48271,8 @@
       }
     },
     "big-integer": {
-      "version": "1.6.51"
+      "version": "1.6.51",
+      "dev": true
     },
     "big.js": {
       "version": "5.2.2"
@@ -49547,6 +48336,7 @@
     },
     "bplist-parser": {
       "version": "0.2.0",
+      "dev": true,
       "requires": {
         "big-integer": "^1.6.44"
       }
@@ -49618,18 +48408,14 @@
       "version": "1.1.2"
     },
     "builtin-modules": {
-      "version": "3.3.0"
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="
     },
     "builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ=="
-    },
-    "bundle-name": {
-      "version": "3.0.0",
-      "requires": {
-        "run-applescript": "^5.0.0"
-      }
     },
     "bytes": {
       "version": "3.0.0"
@@ -49816,6 +48602,8 @@
     },
     "chrome-launcher": {
       "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+      "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
       "requires": {
         "@types/node": "*",
         "escape-string-regexp": "^4.0.0",
@@ -49824,7 +48612,9 @@
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         }
       }
     },
@@ -49833,6 +48623,8 @@
     },
     "chromium-bidi": {
       "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
+      "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
       "requires": {
         "mitt": "3.0.0"
       }
@@ -49996,7 +48788,9 @@
       "version": "11.1.0"
     },
     "comment-parser": {
-      "version": "1.4.0"
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg=="
     },
     "common-path-prefix": {
       "version": "3.0.0"
@@ -50087,6 +48881,8 @@
     },
     "configstore": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
       "requires": {
         "dot-prop": "^5.2.0",
         "graceful-fs": "^4.1.2",
@@ -50098,15 +48894,21 @@
       "dependencies": {
         "make-dir": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "requires": {
             "semver": "^6.0.0"
           }
         },
         "semver": {
-          "version": "6.3.1"
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         },
         "write-file-atomic": {
           "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
           "requires": {
             "imurmurhash": "^0.1.4",
             "is-typedarray": "^1.0.0",
@@ -50299,7 +49101,9 @@
       "version": "2.0.0"
     },
     "csp_evaluator": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.1.tgz",
+      "integrity": "sha512-N3ASg0C4kNPUaNxt1XAvzHIVuzdtr8KLgfk1O8WDyimp1GisPAHESupArO2ieHk9QWbrJ/WkQODyh21Ps/xhxw=="
     },
     "css-color-keywords": {
       "version": "1.0.0",
@@ -50478,6 +49282,8 @@
     },
     "cwd": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
+      "integrity": "sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==",
       "requires": {
         "find-pkg": "^0.1.2",
         "fs-exists-sync": "^0.1.0"
@@ -50487,7 +49293,9 @@
       "version": "1.0.8"
     },
     "data-uri-to-buffer": {
-      "version": "6.0.1"
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.1.tgz",
+      "integrity": "sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg=="
     },
     "data-urls": {
       "version": "3.0.2",
@@ -50581,88 +49389,9 @@
       "version": "1.3.6",
       "requires": {}
     },
-    "default-browser": {
-      "version": "4.0.0",
-      "requires": {
-        "bundle-name": "^3.0.0",
-        "default-browser-id": "^3.0.0",
-        "execa": "^7.1.1",
-        "titleize": "^3.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.3",
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "execa": {
-          "version": "7.2.0",
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^6.0.1",
-            "human-signals": "^4.3.0",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
-            "signal-exit": "^3.0.7",
-            "strip-final-newline": "^3.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "6.0.1"
-        },
-        "human-signals": {
-          "version": "4.3.1"
-        },
-        "is-stream": {
-          "version": "3.0.0"
-        },
-        "mimic-fn": {
-          "version": "4.0.0"
-        },
-        "npm-run-path": {
-          "version": "5.1.0",
-          "requires": {
-            "path-key": "^4.0.0"
-          },
-          "dependencies": {
-            "path-key": {
-              "version": "4.0.0"
-            }
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0"
-        },
-        "strip-final-newline": {
-          "version": "3.0.0"
-        },
-        "which": {
-          "version": "2.0.2",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
     "default-browser-id": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "bplist-parser": "^0.2.0",
         "untildify": "^4.0.0"
@@ -50751,18 +49480,12 @@
     },
     "degenerator": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "requires": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
         "esprima": "^4.0.1"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.13.4",
-          "requires": {
-            "tslib": "^2.0.1"
-          }
-        }
       }
     },
     "del": {
@@ -50999,6 +49722,8 @@
     },
     "dot-prop": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "requires": {
         "is-obj": "^2.0.0"
       }
@@ -51256,202 +49981,33 @@
       }
     },
     "esbuild": {
-      "version": "0.17.15",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
       "devOptional": true,
-      "peer": true,
       "requires": {
-        "@esbuild/android-arm": "0.17.15",
-        "@esbuild/android-arm64": "0.17.15",
-        "@esbuild/android-x64": "0.17.15",
-        "@esbuild/darwin-arm64": "0.17.15",
-        "@esbuild/darwin-x64": "0.17.15",
-        "@esbuild/freebsd-arm64": "0.17.15",
-        "@esbuild/freebsd-x64": "0.17.15",
-        "@esbuild/linux-arm": "0.17.15",
-        "@esbuild/linux-arm64": "0.17.15",
-        "@esbuild/linux-ia32": "0.17.15",
-        "@esbuild/linux-loong64": "0.17.15",
-        "@esbuild/linux-mips64el": "0.17.15",
-        "@esbuild/linux-ppc64": "0.17.15",
-        "@esbuild/linux-riscv64": "0.17.15",
-        "@esbuild/linux-s390x": "0.17.15",
-        "@esbuild/linux-x64": "0.17.15",
-        "@esbuild/netbsd-x64": "0.17.15",
-        "@esbuild/openbsd-x64": "0.17.15",
-        "@esbuild/sunos-x64": "0.17.15",
-        "@esbuild/win32-arm64": "0.17.15",
-        "@esbuild/win32-ia32": "0.17.15",
-        "@esbuild/win32-x64": "0.17.15"
-      },
-      "dependencies": {
-        "@esbuild/android-arm": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.15.tgz",
-          "integrity": "sha512-sRSOVlLawAktpMvDyJIkdLI/c/kdRTOqo8t6ImVxg8yT7LQDUYV5Rp2FKeEosLr6ZCja9UjYAzyRSxGteSJPYg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/android-arm64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.15.tgz",
-          "integrity": "sha512-0kOB6Y7Br3KDVgHeg8PRcvfLkq+AccreK///B4Z6fNZGr/tNHX0z2VywCc7PTeWp+bPvjA5WMvNXltHw5QjAIA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/android-x64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.15.tgz",
-          "integrity": "sha512-MzDqnNajQZ63YkaUWVl9uuhcWyEyh69HGpMIrf+acR4otMkfLJ4sUCxqwbCyPGicE9dVlrysI3lMcDBjGiBBcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/darwin-x64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.15.tgz",
-          "integrity": "sha512-NbImBas2rXwYI52BOKTW342Tm3LTeVlaOQ4QPZ7XuWNKiO226DisFk/RyPk3T0CKZkKMuU69yOvlapJEmax7cg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/freebsd-arm64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.15.tgz",
-          "integrity": "sha512-Xk9xMDjBVG6CfgoqlVczHAdJnCs0/oeFOspFap5NkYAmRCT2qTn1vJWA2f419iMtsHSLm+O8B6SLV/HlY5cYKg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/freebsd-x64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.15.tgz",
-          "integrity": "sha512-3TWAnnEOdclvb2pnfsTWtdwthPfOz7qAfcwDLcfZyGJwm1SRZIMOeB5FODVhnM93mFSPsHB9b/PmxNNbSnd0RQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/linux-arm": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.15.tgz",
-          "integrity": "sha512-MLTgiXWEMAMr8nmS9Gigx43zPRmEfeBfGCwxFQEMgJ5MC53QKajaclW6XDPjwJvhbebv+RzK05TQjvH3/aM4Xw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/linux-arm64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.15.tgz",
-          "integrity": "sha512-T0MVnYw9KT6b83/SqyznTs/3Jg2ODWrZfNccg11XjDehIved2oQfrX/wVuev9N936BpMRaTR9I1J0tdGgUgpJA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/linux-ia32": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.15.tgz",
-          "integrity": "sha512-wp02sHs015T23zsQtU4Cj57WiteiuASHlD7rXjKUyAGYzlOKDAjqK6bk5dMi2QEl/KVOcsjwL36kD+WW7vJt8Q==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/linux-loong64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.15.tgz",
-          "integrity": "sha512-k7FsUJjGGSxwnBmMh8d7IbObWu+sF/qbwc+xKZkBe/lTAF16RqxRCnNHA7QTd3oS2AfGBAnHlXL67shV5bBThQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/linux-mips64el": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.15.tgz",
-          "integrity": "sha512-ZLWk6czDdog+Q9kE/Jfbilu24vEe/iW/Sj2d8EVsmiixQ1rM2RKH2n36qfxK4e8tVcaXkvuV3mU5zTZviE+NVQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/linux-ppc64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.15.tgz",
-          "integrity": "sha512-mY6dPkIRAiFHRsGfOYZC8Q9rmr8vOBZBme0/j15zFUKM99d4ILY4WpOC7i/LqoY+RE7KaMaSfvY8CqjJtuO4xg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/linux-riscv64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.15.tgz",
-          "integrity": "sha512-EcyUtxffdDtWjjwIH8sKzpDRLcVtqANooMNASO59y+xmqqRYBBM7xVLQhqF7nksIbm2yHABptoioS9RAbVMWVA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/linux-s390x": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.15.tgz",
-          "integrity": "sha512-BuS6Jx/ezxFuHxgsfvz7T4g4YlVrmCmg7UAwboeyNNg0OzNzKsIZXpr3Sb/ZREDXWgt48RO4UQRDBxJN3B9Rbg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/linux-x64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.15.tgz",
-          "integrity": "sha512-JsdS0EgEViwuKsw5tiJQo9UdQdUJYuB+Mf6HxtJSPN35vez1hlrNb1KajvKWF5Sa35j17+rW1ECEO9iNrIXbNg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/netbsd-x64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.15.tgz",
-          "integrity": "sha512-R6fKjtUysYGym6uXf6qyNephVUQAGtf3n2RCsOST/neIwPqRWcnc3ogcielOd6pT+J0RDR1RGcy0ZY7d3uHVLA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/openbsd-x64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.15.tgz",
-          "integrity": "sha512-mVD4PGc26b8PI60QaPUltYKeSX0wxuy0AltC+WCTFwvKCq2+OgLP4+fFd+hZXzO2xW1HPKcytZBdjqL6FQFa7w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/sunos-x64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.15.tgz",
-          "integrity": "sha512-U6tYPovOkw3459t2CBwGcFYfFRjivcJJc1WC8Q3funIwX8x4fP+R6xL/QuTPNGOblbq/EUDxj9GU+dWKX0oWlQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/win32-arm64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.15.tgz",
-          "integrity": "sha512-W+Z5F++wgKAleDABemiyXVnzXgvRFs+GVKThSI+mGgleLWluv0D7Diz4oQpgdpNzh4i2nNDzQtWbjJiqutRp6Q==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/win32-ia32": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.15.tgz",
-          "integrity": "sha512-Muz/+uGgheShKGqSVS1KsHtCyEzcdOn/W/Xbh6H91Etm+wiIfwZaBn1W58MeGtfI8WA961YMHFYTthBdQs4t+w==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "@esbuild/win32-x64": {
-          "version": "0.17.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.15.tgz",
-          "integrity": "sha512-DjDa9ywLUUmjhV2Y9wUTIF+1XsmuFGvZoCmOWkli1XcNAh5t25cc7fgsCx4Zi/Uurep3TTLyDiKATgGEg61pkA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        }
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
       }
     },
     "esbuild-plugin-alias": {
@@ -51680,6 +50236,8 @@
     },
     "eslint-config-prettier": {
       "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "requires": {}
     },
     "eslint-import-resolver-babel-module": {
@@ -51795,42 +50353,63 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "27.6.0",
+      "version": "27.6.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.6.3.tgz",
+      "integrity": "sha512-+YsJFVH6R+tOiO3gCJon5oqn4KWc+mDq2leudk8mrp8RFubLOo9CVyi3cib4L7XMpxExmkmBZQTPDYVBzgpgOA==",
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "46.8.2",
+      "version": "46.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
+      "integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
       "requires": {
-        "@es-joy/jsdoccomment": "~0.40.1",
+        "@es-joy/jsdoccomment": "~0.41.0",
         "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.0",
+        "comment-parser": "1.4.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.5.0",
         "is-builtin-module": "^3.2.1",
         "semver": "^7.5.4",
-        "spdx-expression-parse": "^3.0.1"
+        "spdx-expression-parse": "^4.0.0"
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         },
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
+        "spdx-expression-parse": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+          "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -51868,6 +50447,8 @@
     },
     "eslint-plugin-playwright": {
       "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
+      "integrity": "sha512-LQMW5y0DLK5Fnpya7JR1oAYL2/7Y9wDiYw6VZqlKqcRGSgjbVKNqxraphk7ra1U3Bb5EK444xMgUlQPbMg2M1g==",
       "requires": {}
     },
     "eslint-plugin-react": {
@@ -52030,6 +50611,8 @@
     },
     "expand-tilde": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "integrity": "sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==",
       "requires": {
         "os-homedir": "^1.0.1"
       }
@@ -52129,10 +50712,14 @@
       "version": "3.1.3"
     },
     "fast-diff": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
     },
     "fast-fifo": {
-      "version": "1.3.2"
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "fast-glob": {
       "version": "3.3.2",
@@ -52308,6 +50895,8 @@
     },
     "find-file-up": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+      "integrity": "sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==",
       "requires": {
         "fs-exists-sync": "^0.1.0",
         "resolve-dir": "^0.1.0"
@@ -52318,12 +50907,16 @@
     },
     "find-pkg": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+      "integrity": "sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==",
       "requires": {
         "find-file-up": "^0.1.2"
       }
     },
     "find-process": {
       "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+      "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
       "requires": {
         "chalk": "^4.0.0",
         "commander": "^5.1.0",
@@ -52332,12 +50925,16 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -52345,21 +50942,31 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "commander": {
-          "version": "5.1.0"
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -52405,7 +51012,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.2"
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -52464,7 +51073,9 @@
       "version": "1.0.0"
     },
     "fs-exists-sync": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg=="
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -52569,6 +51180,8 @@
     },
     "get-uri": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.2.tgz",
+      "integrity": "sha512-5KLucCJobh8vBY1K07EFV4+cPZH3mrV9YeAruUseCQKHB58SGjjT2l9/eA9LD082IiuMjSlFJEcdJ27TXvbZNw==",
       "requires": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.0",
@@ -52578,6 +51191,8 @@
       "dependencies": {
         "fs-extra": {
           "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -52695,18 +51310,24 @@
     },
     "global-modules": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==",
       "requires": {
         "global-prefix": "^0.1.4",
         "is-windows": "^0.2.0"
       },
       "dependencies": {
         "is-windows": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q=="
         }
       }
     },
     "global-prefix": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==",
       "requires": {
         "homedir-polyfill": "^1.0.0",
         "ini": "^1.3.4",
@@ -52715,7 +51336,9 @@
       },
       "dependencies": {
         "is-windows": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q=="
         }
       }
     },
@@ -52873,6 +51496,8 @@
     },
     "homedir-polyfill": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "requires": {
         "parse-passwd": "^1.0.0"
       }
@@ -52947,7 +51572,9 @@
       }
     },
     "http-link-header": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.1.tgz",
+      "integrity": "sha512-mW3N/rTYpCn99s1do0zx6nzFZSwLH9HGfUM4ZqLWJ16ylmYaC2v5eYGqrNTQlByx8AzUgGI+V/32gXPugs1+Sw=="
     },
     "http-parser-js": {
       "version": "0.5.8"
@@ -53022,7 +51649,9 @@
       }
     },
     "image-ssim": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg=="
     },
     "immutable": {
       "version": "4.3.0"
@@ -53135,12 +51764,16 @@
     },
     "intl-messageformat": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-4.4.0.tgz",
+      "integrity": "sha512-z+Bj2rS3LZSYU4+sNitdHrwnBhr0wO80ZJSW8EzKDBowwUe3Q/UsvgCGjrwa+HPzoGCLEb9HAjfJgo4j2Sac8w==",
       "requires": {
         "intl-messageformat-parser": "^1.8.1"
       }
     },
     "intl-messageformat-parser": {
-      "version": "1.8.1"
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.8.1.tgz",
+      "integrity": "sha512-IMSCKVf0USrM/959vj3xac7s8f87sc+80Y/ipBzdKy4ifBv5Gsj2tZ41EAaURVg01QU71fYr77uA8Meh6kELbg=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -53155,7 +51788,9 @@
       "version": "2.1.0"
     },
     "irregular-plurals": {
-      "version": "3.5.0"
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+      "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ=="
     },
     "is-absolute-url": {
       "version": "3.0.3",
@@ -53209,6 +51844,8 @@
     },
     "is-builtin-module": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
       "requires": {
         "builtin-modules": "^3.3.0"
       }
@@ -53276,17 +51913,6 @@
       "version": "1.0.0",
       "dev": true
     },
-    "is-inside-container": {
-      "version": "1.0.0",
-      "requires": {
-        "is-docker": "^3.0.0"
-      },
-      "dependencies": {
-        "is-docker": {
-          "version": "3.0.0"
-        }
-      }
-    },
     "is-interactive": {
       "version": "1.0.0",
       "dev": true
@@ -53315,7 +51941,9 @@
       }
     },
     "is-obj": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
     "is-path-cwd": {
       "version": "2.2.0"
@@ -53398,7 +52026,9 @@
       }
     },
     "is-typedarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "is-unicode-supported": {
       "version": "0.1.0"
@@ -53826,25 +52456,31 @@
       }
     },
     "jest-dev-server": {
-      "version": "6.2.0",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-9.0.2.tgz",
+      "integrity": "sha512-Zc/JB0IlNNrpXkhBw+h86cGrde/Mey52KvF+FER2eyrtYJTHObOwW7Iarxm3rPyTKby5+3Y2QZtl8pRz/5GCxg==",
       "requires": {
         "chalk": "^4.1.2",
         "cwd": "^0.10.0",
         "find-process": "^1.4.7",
         "prompts": "^2.4.2",
-        "spawnd": "^6.2.0",
+        "spawnd": "^9.0.2",
         "tree-kill": "^1.2.2",
-        "wait-on": "^6.0.1"
+        "wait-on": "^7.2.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -53852,18 +52488,26 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -54544,20 +53188,26 @@
       "dev": true
     },
     "joi": {
-      "version": "17.9.1",
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.0.tgz",
+      "integrity": "sha512-HSLsmSmXz+PV9PYoi3p7cgIbj06WnEBNT28n+bbBNcPZXZFqCzzvGqpTBPujx/Z0nh1+KNQPDrNgdmQ8dq0qYw==",
       "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.4",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
     },
     "jpeg-js": {
-      "version": "0.4.4"
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
     },
     "js-library-detector": {
-      "version": "6.7.0"
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.7.0.tgz",
+      "integrity": "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA=="
     },
     "js-tokens": {
       "version": "4.0.0"
@@ -54664,7 +53314,9 @@
       }
     },
     "jsdoc-type-pratt-parser": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ=="
     },
     "jsdom": {
       "version": "20.0.3",
@@ -54822,6 +53474,8 @@
     },
     "lighthouse": {
       "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-10.4.0.tgz",
+      "integrity": "sha512-XQWHEWkJ8YxSPsxttBJORy5+hQrzbvGkYfeP3fJjyYKioWkF2MXfFqNK4ZuV4jL8pBu7Z91qnQP6In0bq1yXww==",
       "requires": {
         "@sentry/node": "^6.17.4",
         "axe-core": "4.7.2",
@@ -54853,25 +53507,35 @@
       },
       "dependencies": {
         "axe-core": {
-          "version": "4.7.2"
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
+          "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g=="
         },
         "cross-fetch": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+          "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
           "requires": {
             "node-fetch": "^2.6.12"
           }
         },
         "devtools-protocol": {
-          "version": "0.0.1155343"
+          "version": "0.0.1155343",
+          "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1155343.tgz",
+          "integrity": "sha512-oD9vGBV2wTc7fAzAM6KC0chSgs234V8+qDEeK+mcbRj2UvcuA7lgBztGi/opj/iahcXD3BSj8Ymvib628yy9FA=="
         },
         "node-fetch": {
           "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
         },
         "puppeteer-core": {
           "version": "20.9.0",
+          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
+          "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
           "requires": {
             "@puppeteer/browsers": "1.4.6",
             "chromium-bidi": "0.4.16",
@@ -54882,25 +53546,35 @@
           },
           "dependencies": {
             "devtools-protocol": {
-              "version": "0.0.1147663"
+              "version": "0.0.1147663",
+              "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
+              "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ=="
             },
             "ws": {
               "version": "8.13.0",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+              "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
               "requires": {}
             }
           }
         },
         "ws": {
           "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
           "requires": {}
         },
         "yargs-parser": {
-          "version": "21.1.1"
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
     },
     "lighthouse-logger": {
       "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
       "requires": {
         "debug": "^2.6.9",
         "marky": "^1.2.2"
@@ -54908,17 +53582,23 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
         },
         "ms": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
     },
     "lighthouse-stack-packs": {
-      "version": "1.11.0"
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.11.0.tgz",
+      "integrity": "sha512-sRr0z1S/I26VffRLq9KJsKtLk856YrJlNGmcJmbLX8dFn3MuzVPUbstuChEhqnSxZb8TZmVfthuXuwhG9vRoSw=="
     },
     "lilconfig": {
       "version": "2.1.0"
@@ -55049,7 +53729,9 @@
       }
     },
     "lookup-closest-locale": {
-      "version": "6.2.0"
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
+      "integrity": "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -55064,7 +53746,9 @@
       }
     },
     "lru_map": {
-      "version": "0.3.3"
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -55213,7 +53897,9 @@
       "version": "0.16.0"
     },
     "marky": {
-      "version": "1.2.5"
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
+      "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q=="
     },
     "mathml-tag-names": {
       "version": "2.1.3"
@@ -55300,7 +53986,9 @@
       "version": "1.4.1"
     },
     "metaviewport-parser": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
+      "integrity": "sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ=="
     },
     "methods": {
       "version": "1.1.2"
@@ -55410,7 +54098,9 @@
       }
     },
     "mitt": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "mixin-object": {
       "version": "2.0.1",
@@ -55483,7 +54173,9 @@
       "version": "2.6.2"
     },
     "netmask": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
     },
     "no-case": {
       "version": "3.0.4",
@@ -55588,6 +54280,8 @@
     },
     "npm-package-json-lint": {
       "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-6.4.0.tgz",
+      "integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
       "requires": {
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",
@@ -55610,21 +54304,29 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "argparse": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "builtins": {
           "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+          "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
           "requires": {
             "semver": "^7.0.0"
           }
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -55632,15 +54334,21 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "cosmiconfig": {
           "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+          "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
           "requires": {
             "import-fresh": "^3.3.0",
             "js-yaml": "^4.1.0",
@@ -55649,34 +54357,48 @@
           }
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "hosted-git-info": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "is-plain-obj": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+          "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="
         },
         "js-yaml": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "requires": {
             "argparse": "^2.0.1"
           }
         },
         "jsonc-parser": {
-          "version": "3.2.0"
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+          "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
         },
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "meow": {
           "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+          "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
           "requires": {
             "@types/minimist": "^1.2.0",
             "camelcase-keys": "^6.2.2",
@@ -55693,12 +54415,16 @@
           },
           "dependencies": {
             "type-fest": {
-              "version": "0.18.1"
+              "version": "0.18.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+              "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
             }
           }
         },
         "normalize-package-data": {
           "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
           "requires": {
             "hosted-git-info": "^4.0.1",
             "is-core-module": "^2.5.0",
@@ -55708,30 +54434,42 @@
         },
         "semver": {
           "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
         },
         "type-fest": {
-          "version": "3.13.1"
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+          "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
         },
         "validate-npm-package-name": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
+          "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
           "requires": {
             "builtins": "^5.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yargs-parser": {
-          "version": "20.2.9"
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
       }
     },
@@ -55941,7 +54679,9 @@
       }
     },
     "os-homedir": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ=="
     },
     "os-tmpdir": {
       "version": "1.0.2"
@@ -55984,6 +54724,8 @@
     },
     "pac-proxy-agent": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
       "requires": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.0.2",
@@ -55997,12 +54739,16 @@
       "dependencies": {
         "agent-base": {
           "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
           "requires": {
             "debug": "^4.3.4"
           }
         },
         "http-proxy-agent": {
           "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+          "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
           "requires": {
             "agent-base": "^7.1.0",
             "debug": "^4.3.4"
@@ -56010,6 +54756,8 @@
         },
         "https-proxy-agent": {
           "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
           "requires": {
             "agent-base": "^7.0.2",
             "debug": "4"
@@ -56019,6 +54767,8 @@
     },
     "pac-resolver": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
+      "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
       "requires": {
         "degenerator": "^5.0.0",
         "ip": "^1.1.8",
@@ -56026,7 +54776,9 @@
       },
       "dependencies": {
         "ip": {
-          "version": "1.1.8"
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
+          "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
         }
       }
     },
@@ -56052,7 +54804,9 @@
       }
     },
     "parse-cache-control": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
     },
     "parse-json": {
       "version": "5.2.0",
@@ -56064,7 +54818,9 @@
       }
     },
     "parse-passwd": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q=="
     },
     "parse5": {
       "version": "7.1.2",
@@ -56196,24 +54952,32 @@
       }
     },
     "playwright": {
-      "version": "1.39.0",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.1.tgz",
+      "integrity": "sha512-gdZAWG97oUnbBdRL3GuBvX3nDDmUOuqzV/D24dytqlKt+eI5KbwusluZRGljx1YoJKZ2NRPaeWiFTeGZO7SosQ==",
       "peer": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.39.0"
+        "playwright-core": "1.41.1"
       },
       "dependencies": {
         "playwright-core": {
-          "version": "1.39.0",
+          "version": "1.41.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.1.tgz",
+          "integrity": "sha512-/KPO5DzXSMlxSX77wy+HihKGOunh3hqndhqeo/nMxfigiKzogn8kfL0ZBDu0L1RKgan5XHCPmn6zXd2NUJgjhg==",
           "peer": true
         }
       }
     },
     "playwright-core": {
-      "version": "1.32.0"
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw=="
     },
     "plur": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
       "requires": {
         "irregular-plurals": "^3.2.0"
       }
@@ -56568,6 +55332,8 @@
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "requires": {
         "fast-diff": "^1.1.2"
       }
@@ -56641,6 +55407,8 @@
     },
     "proxy-agent": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
+      "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
       "requires": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -56654,12 +55422,16 @@
       "dependencies": {
         "agent-base": {
           "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
           "requires": {
             "debug": "^4.3.4"
           }
         },
         "http-proxy-agent": {
           "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+          "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
           "requires": {
             "agent-base": "^7.1.0",
             "debug": "^4.3.4"
@@ -56667,13 +55439,17 @@
         },
         "https-proxy-agent": {
           "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
           "requires": {
             "agent-base": "^7.0.2",
             "debug": "4"
           }
         },
         "lru-cache": {
-          "version": "7.18.3"
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
         }
       }
     },
@@ -56684,7 +55460,9 @@
       "version": "1.1.0"
     },
     "ps-list": {
-      "version": "8.1.1"
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-8.1.1.tgz",
+      "integrity": "sha512-OPS9kEJYVmiO48u/B9qneqhkMvgCxT+Tm28VCEJpheTpl8cJ0ffZRRNgS5mrQRTrX5yRTpaJ+hRDeefXYmmorQ=="
     },
     "pseudomap": {
       "version": "1.0.2"
@@ -56754,7 +55532,9 @@
       "version": "1.2.3"
     },
     "queue-tick": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
     },
     "quick-lru": {
       "version": "4.0.1"
@@ -57149,7 +55929,9 @@
       "version": "2.0.0"
     },
     "requireindex": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
     },
     "requires-port": {
       "version": "1.0.0"
@@ -57176,6 +55958,8 @@
     },
     "resolve-dir": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "integrity": "sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==",
       "requires": {
         "expand-tilde": "^1.2.2",
         "global-modules": "^0.2.3"
@@ -57237,64 +56021,17 @@
       }
     },
     "robots-parser": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ=="
     },
     "rollup": {
-      "version": "3.24.0",
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "devOptional": true,
       "requires": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "run-applescript": {
-      "version": "5.0.0",
-      "requires": {
-        "execa": "^5.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.3",
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "execa": {
-          "version": "5.1.1",
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^6.0.0",
-            "human-signals": "^2.1.0",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.1",
-            "onetime": "^5.1.2",
-            "signal-exit": "^3.0.3",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "6.0.1"
-        },
-        "human-signals": {
-          "version": "2.1.0"
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0"
-        },
-        "which": {
-          "version": "2.0.2",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "run-async": {
@@ -57756,7 +56493,9 @@
       }
     },
     "smart-buffer": {
-      "version": "4.2.0"
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "smartwrap": {
       "version": "2.0.2",
@@ -57851,6 +56590,8 @@
     },
     "socks": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "requires": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -57858,6 +56599,8 @@
     },
     "socks-proxy-agent": {
       "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+      "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
       "requires": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -57866,6 +56609,8 @@
       "dependencies": {
         "agent-base": {
           "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
           "requires": {
             "debug": "^4.3.4"
           }
@@ -57917,11 +56662,19 @@
       "dev": true
     },
     "spawnd": {
-      "version": "6.2.0",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-9.0.2.tgz",
+      "integrity": "sha512-nl8DVHEDQ57IcKakzpjanspVChkMpGLuVwMR/eOn9cXE55Qr6luD2Kn06sA0ootRMdgrU4tInN6lA6ohTNvysw==",
       "requires": {
-        "exit": "^0.1.2",
-        "signal-exit": "^3.0.7",
+        "signal-exit": "^4.1.0",
         "tree-kill": "^1.2.2"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+        }
       }
     },
     "spawndamnit": {
@@ -57975,6 +56728,8 @@
     },
     "speedline-core": {
       "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz",
+      "integrity": "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==",
       "requires": {
         "@types/node": "*",
         "image-ssim": "^0.2.0",
@@ -58033,7 +56788,9 @@
       }
     },
     "streamx": {
-      "version": "2.15.2",
+      "version": "2.15.6",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
       "requires": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
@@ -58296,10 +57053,14 @@
     },
     "stylelint-config-recommended": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
+      "integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
       "requires": {}
     },
     "stylelint-config-recommended-scss": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz",
+      "integrity": "sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==",
       "requires": {
         "postcss-scss": "^4.0.2",
         "stylelint-config-recommended": "^6.0.0",
@@ -58393,10 +57154,12 @@
       "dev": true
     },
     "synckit": {
-      "version": "0.8.5",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
+      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
       "requires": {
-        "@pkgr/utils": "^2.3.1",
-        "tslib": "^2.5.0"
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
       }
     },
     "table": {
@@ -58649,7 +57412,9 @@
       "version": "0.2.0"
     },
     "third-party-web": {
-      "version": "0.23.4"
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.23.4.tgz",
+      "integrity": "sha512-kwYnSZRhEvv0SBW2fp8SBBKRglMoBjV8xz6C31m0ewqOtknB5UL+Ihg+M81hyFY5ldkZuGWPb+e4GVDkzf/gYg=="
     },
     "through": {
       "version": "2.3.8"
@@ -58702,9 +57467,6 @@
       "version": "1.3.1",
       "dev": true
     },
-    "titleize": {
-      "version": "3.0.0"
-    },
     "tmp": {
       "version": "0.0.33",
       "requires": {
@@ -58751,7 +57513,9 @@
       "version": "0.0.3"
     },
     "tree-kill": {
-      "version": "1.2.2"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
     },
     "trim-newlines": {
       "version": "3.0.1"
@@ -58979,12 +57743,16 @@
     },
     "tsutils": {
       "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "requires": {
         "tslib": "^1.8.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -59121,6 +57889,8 @@
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "requires": {
         "is-typedarray": "^1.0.0"
       }
@@ -59220,7 +57990,8 @@
       }
     },
     "untildify": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "update-browserslist-db": {
       "version": "1.0.13",
@@ -59361,14 +58132,16 @@
       "version": "1.1.2"
     },
     "vite": {
-      "version": "4.3.9",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "devOptional": true,
       "peer": true,
       "requires": {
-        "esbuild": "^0.17.5",
+        "esbuild": "^0.18.10",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.23",
-        "rollup": "^3.21.0"
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       }
     },
     "w3c-xmlserializer": {
@@ -59378,17 +58151,21 @@
       }
     },
     "wait-on": {
-      "version": "6.0.1",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
       "requires": {
-        "axios": "^0.25.0",
-        "joi": "^17.6.0",
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.5",
-        "rxjs": "^7.5.4"
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       },
       "dependencies": {
         "rxjs": {
-          "version": "7.8.0",
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
           "requires": {
             "tslib": "^2.1.0"
           }
@@ -59420,6 +58197,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-vitals": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.1.tgz",
+      "integrity": "sha512-xQ9lvIpfLxUj0eSmT79ZjRoU5wIRfIr7pNukL7ZE4EcWZSmfZQqOlhuAGfkVa3EFmzPHZhWhXfm2i5ys+THVPg=="
     },
     "webidl-conversions": {
       "version": "3.0.1"
@@ -59932,7 +58714,9 @@
       "requires": {}
     },
     "xdg-basedir": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
     },
     "xml-name-validator": {
       "version": "4.0.0"

--- a/packages/block-editor-tools/README.md
+++ b/packages/block-editor-tools/README.md
@@ -16,6 +16,7 @@ npm install @alleyinteractive/block-editor-tools --save
 
 To use modules from this package, import them into your files using the `import` declaration.
 
+**Example**
 ```jsx
 import { usePostMeta } from '@alleyinteractive/block-editor-tools';
 
@@ -32,6 +33,797 @@ const MyComponent = () => {
   );
 };
 ```
+
+Below is the documentation for all available components, hooks, and services.
+
+## Components
+
+React components that can be used within the WordPress block editor.
+
+### [AudioPicker](src/components/audio-picker/)
+
+Allows a user to select or remove audio using the media modal or via direct
+URL entry. This component is a thin wrapper around `MediaPicker` and sets the
+allowed types for the `MediaPicker` to `audio` as well as provides a custom
+preview component that embeds the selected audio in the editor.
+
+For more information on how to use this component, see
+[MediaPicker](src/components/media-picker/README.md).
+
+**Usage**
+
+``` js
+<AudioPicker
+  className="audio-picker"
+  onReset={() => setAttributes({ audioId: 0 })}
+  onUpdate={({ id }) => setAttributes({ audioId: id })}
+  value={audioId}
+/>
+```
+
+**Props**
+
+| Prop        | Default     | Required | Type     | Description                                                                                              |
+|-------------|-------------|----------|----------|----------------------------------------------------------------------------------------------------------|
+| className   | ''          | No       | string   | Class name for the media picker container.                                                               |
+| onReset     |             | Yes      | function | Function to reset the audio ID to 0 and/or the audio URL to an empty string.                             |
+| onUpdate    |             | Yes      | function | Function to set the audio ID on audio selection/upload.                                                  |
+| onUpdateURL | null        | No       | function | Function to set the audio URL on entry. If not set, the button to enter a URL manually will not display. |
+| value       |             | Yes      | integer  | The ID of the selected audio. 0 represents no selection.                                                 |
+| valueURL    | ''          | No       | string   | The URL of the audio. An empty string represents no selection.                                           |
+
+### Checkboxes
+
+Provides a UI component that uses the `Checkbox` component to render the equivalent
+of a multi-select without needing to use the `SelectControl` component.
+
+#### Usage
+
+``` js
+<Checkboxes
+  label={__('Setting', 'alley-scripts')}
+  value={setting}
+  onChange={(newValue) => setAttributes({ setting: newValue })}
+  options={[
+    { value: 'option-1', label: __('Option 1', 'alley-scripts') },
+    { value: 'option-2', label: __('Option 2', 'alley-scripts') },
+  ]}
+/>
+```
+
+#### Props
+
+| Prop        | Default     | Required | Type     | Description                                                                                              |
+|-------------|-------------|----------|----------|----------------------------------------------------------------------------------------------------------|
+| label       |             | Yes      | string   | The label for the component.                                                                             |
+| value       |             | Yes      | array    | The current value as an array of strings.                                                                |
+| options     |             | Yes      | array    | Available options to choose from with a structure of `{ value: '', label: '' }`.                         |
+| onChange    |             | Yes      | function | Function called with the selected options after the user makes an update.                                |
+
+
+### CSVUploader
+
+Allows a user to upload a CSV file, which is parsed in the browser, converted to a JSON structure, passed through a user specified callback function for further transformation, and saved to block attributes. This component is intended to be used to save the resulting JSON data to postmeta, but that is controlled in the parent block scope.
+
+#### Usage
+
+Render a CSV upload component with a callback to further process the JSON data.
+```jsx
+  <CSVUploader
+    attributeName="data"
+    callback={transformData}
+    setAttributes={setAttributes}
+  /> 
+```
+#### Callback Function
+
+The callback function is optional, and allows for further processing of the data returned by the parser.
+
+The callback function accepts an array of objects as its only parameter. Each object will be a description of one row in the CSV, with keys matching the headers in the file.
+
+Given a CSV file in the following format:
+```csv
+title,slug,description
+Sample Title,sample-title,Lorem ipsum dolor sit amet.
+```
+The array of objects passed to the callback function will take the following form:
+```js
+[
+  {
+    title: 'Sample Title',
+    slug: 'sample-title',
+    description: 'Lorem ipsum dolor sit amet.',
+  },
+]
+```
+
+Under the hood, the CSV parser uses PapaParse and attempts to make intelligent choices about data formats based on data in each column. Columns of integers should come through as integers, for example.
+
+### ImagePicker
+
+Allows a user to select or remove an image using the media modal or via direct
+URL entry. This component is a thin wrapper around `MediaPicker` and sets the
+allowed types for the `MediaPicker` to `image` as well as provides a custom
+preview component that embeds the selected image in the editor.
+
+For more information on how to use this component, see
+[MediaPicker](../media-picker/README.md).
+
+**Usage**
+
+``` jsx
+<ImagePicker
+  className="image-picker"
+  imageSize="thumbnail"
+  onReset={() => setAttributes({ imageId: 0 })}
+  onUpdate={({ id }) => setAttributes({ imageId: id })}
+  value={imageId}
+/>
+```
+
+**Props**
+
+| Prop         | Default     | Required | Type     | Description                                                                                              |
+|--------------|-------------|----------|----------|----------------------------------------------------------------------------------------------------------|
+| className    | ''          | No       | string   | Class name for the media picker container.                                                               |
+| imageSize    | 'thumbnail' | No       | string   | The size to display in the preview.                                                                      |
+| displayControlsInToolbar | false | No | boolean | Determines if controls should render in the block toolbar.                                                |
+| onReset      |             | Yes      | function | Function to reset the image ID to 0 and/or the image URL to an empty string.                             |
+| onUpdate     |             | Yes      | function | Function to set the image ID on image selection/upload.                                                  |
+| onUpdateURL  | null        | No       | function | Function to set the image URL on entry. If not set, the button to enter a URL manually will not display. |
+| value        |             | Yes      | integer  | The ID of the selected image. 0 represents no selection.                                                 |
+| valueURL     | ''          | No       | string   | The URL of the image. An empty string represents no selection.                                           |
+
+### MediaPicker
+
+Allows for a simple media upload/replace/remove feature for media for blocks.
+
+**Usage**
+
+``` js
+<MediaPicker
+  allowedTypes={['application/pdf']}
+  className="media-picker"
+  onReset={() => setAttributes({ mediaId: 0 })}
+  onUpdate={({ id }) => setAttributes({ mediaId: id })}
+  value={mediaId}
+/>
+```
+
+The value of `mediaId` is the ID of the media element, and is destructured from
+`props.attributes`.
+
+There are additional options for the MediaPicker that can be configured via the
+props listed below. For example, the MediaPicker also supports URL entry as well
+as custom preview components, which is useful when you want to render an image
+or an embed instead of just a text link to the selected asset.
+
+**Props**
+
+| Prop         | Default        | Required | Type     | Description                                                                                                     |
+|--------------|----------------|----------|----------|-----------------------------------------------------------------------------------------------------------------|
+| allowedTypes | []             | No       | array    | Array with the types of the media to upload/select from the media library. Defaults to empty array (all types). |
+| className    | ''             | No       | string   | Class name for the media picker container.                                                                      |
+| icon         | 'format-aside' | No       | string   | The name of the Dashicon to use next to the title when no selection has been made yet.                          |
+| imageSize    | 'thumbnail'    | No       | string   | If the selected item is an image, the size to display in the preview.                                           |
+| displayControlsInToolbar | false | No | boolean | Determines if controls should render in the block toolbar. |
+| onReset      |                | Yes      | function | Function to reset the attachment ID to 0 and/or the attachment URL to an empty string.                          |
+| onUpdate     |                | Yes      | function | Function to set the attachment ID on attachment selection/upload.                                               |
+| onUpdateURL  | null           | No       | function | Function to set the attachment URL on entry. If not set, the button to enter a URL manually will not display.   |
+| preview      | null           | No       | element  | An optional JSX component that accepts an `src` prop as a string to render the preview upon selection.          |
+| value        |                | Yes      | integer  | The ID of the selected attachment. 0 represents no selection.                                                   |
+| valueURL     | ''             | No       | string   | The URL of the attachment. An empty string represents no selection.                                             |
+
+
+### PostPicker
+
+Allows for a simple post select/replace/remove feature, similar to selecting an item from the media library.
+
+**Usage**
+
+``` js
+<PostPicker
+  allowedTypes={['post']}
+  className="post-picker"
+  onReset={() => setAttributes({ postId: 0 })}
+  onUpdate={( id ) => setAttributes({ postId: id })}
+  value={postId}
+/>
+```
+
+There are additional options for the PostPicker that can be configured via the
+props listed below. For example, the PostPicker also supports customizing the arguments
+sent to the search endpoint, a custom renderer for previews, a custom renderer for search
+results, and a custom function for fetching post data given a post ID.
+
+**Props**
+
+| Prop           | Default        | Required | Type     | Description                                                                                                     |
+|----------------|----------------|----------|----------|-----------------------------------------------------------------------------------------------------------------|
+| allowedTypes   | `[]`         | No       | array    | Array with the post types to select from. Defaults to empty array (all types). |
+| className      | `''`           | No       | string   | Class name for the post picker container.                                                                      |
+| getPostType    |                | No       | function | Function to retrieve the post type for a post ID. This function must return a string. |
+| modalTitle     | `Select Post`  | No       | string   | Title of the modal that shows posts. |
+| onReset        |                | Yes      | function | Function to reset the post ID to 0.                          |
+| onUpdate       |                | Yes      | function | Function to set the post ID on post selection.                                               |
+| params         | `{}`           | No       | object   | Optional key value pairs to append to the search request. Ex: `{ per_page: 20 }`.                     |
+| previewRender  |                | No       | function | Optional component to render the preview of the selected post. Must recieve an object similar to what is returned from the `/wp/v2/posts/<ID>` endpoint. |
+| replaceText    | `Replace`      | No       | string   | Text shown on the button that will open the picker to replace a currently selected post. |
+| resetText      | `Reset`        | No       | string   |Text shown on the button that will reset the picker to having no post selected. |
+| searchEndpoint | `/wp/v2/search` | No | string | Optional search endpoint. |
+| searchRender   |                | No       | function | Optional component to render the preview of posts in the modal window. Must recieve an object similar to what is returned from the `/wp/v2/search` endpoint. |
+| selectText     | `Select`       | No       | string   | Text shown on the button that will open the picker to select a post. |
+| suppressPostIds |                | No       | array    | Array of post ids to not show in the results list. |
+| title          | `''`           | No       | string   | Optional title for the component. |
+| value          |                | Yes      | integer  | The ID of the selected post. 0 represents no selection.                                                   |
+
+### SafeHTML
+
+A lightweight, reusable component for safely creating a component
+that contains arbitrary HTML, such as from a REST API.
+
+Uses `dangerouslySetInnerHTML` and `DOMPurify` under the hood.
+
+Because of how `dangerouslySetInnerHTML` works, you need to
+provide a tag to inject the HTML into. If the HTML you want to
+inject is wrapped in the tag you want to use, you will need to
+strip that out first.
+
+**Usage**
+
+```jsx
+<SafeHTML
+  className="some-classname"
+  html="<p>some arbitrary html</p>"
+  tag="div"
+/>
+```
+
+**Props**
+
+| prop      | required | type   |                                                 |
+|-----------|----------|--------|-------------------------------------------------|
+| className | No       | string | A classname for the element.                    |
+| html      | Yes      | string | The arbitrary HTML to sanitize and inse.rt      |
+| tag       | Yes      | string | The tag name to wrap the HTML in, e.g.,  `div`. |
+
+### Selector
+
+Allows users to select an item or multiple items using a search query against the REST API. Optionally, accepts a list of subtypes to which to restrict the search. Utilizes the search endpoint, so items must have the appropriate visibility within the REST API to appear in the result list.
+
+Importantly, this component does not save the selected item, it just returns it in the `onSelect` method. The enclosing block or component is responsible for managing the selected items in some way, and using this component as a method for picking a new one.
+
+**Usage**
+
+``` js
+  <Selector
+    className="custom-autocomplete-classname"
+    emptyLabel="No items."
+    label="Label"
+    multiple
+    onSelect={onSelect}
+    placeholder="Placeholder..."
+    subTypes={['post', 'page']}
+    selected={[{
+      id: 123,
+      title: 'Title of Element',
+    }]}
+    threshold={3}
+  />
+```
+**Props**
+
+| Prop        | Default          | Required | Type     | Description                                                                                                                 |
+|-------------|------------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| className   |                  | false    | string   | If specified, the className is prepended to the top-level container.                                                        |
+| emptyLabel  | No items found   | false    | string   | If specified, this overrides the default language when no items are found.                                                  |
+| label       | Search for items | false    | string   | If specified, this overrides the default label text for the item selection search input.                                    |
+| multiple    | false            | false    | boolean  | If set to true the component allows for the ability to select multiple items returned through the `onSelect` callback.      |
+| onSelect    | NA               | true     | function | Callback to receive the selected item array, as it is returned from the `search` REST endpoint. Required.                   |
+| placeholder | Search for items | false    | string   | If specified, this overrides the default input placeholder value.                                                           |
+| subTypes   | []               | false    | array    | All queryable subtypes that will be included in the form comma-separated array. The default query is "any" subtype.     |
+| selected    | []               | false    | array    | Optional array of objects with id and title keys to auto-hydrate selections on load.                                        |
+| threshold   | 3                | false    | integer  | If specified, this overrides the default minimum number of characters that must be entered in order for the search to fire. |
+
+
+### TermSelect
+
+A component for selecting terms.
+
+**Usage**
+See the Selector component for usage details. The `type` prop is preset to `term`.
+
+### VideoPicker
+
+Allows a user to select or remove a video using the media modal or via direct
+URL entry. This component is a thin wrapper around `MediaPicker` and sets the
+allowed types for the `MediaPicker` to `video` as well as provides a custom
+preview component that embeds the selected video in the editor.
+
+For more information on how to use this component, see
+[MediaPicker](../media-picker/README.md).
+
+**Usage**
+
+``` js
+<VideoPicker
+  className="video-picker"
+  onReset={() => setAttributes({ videoId: 0 })}
+  onUpdate={({ id }) => setAttributes({ videoId: id })}
+  value={videoId}
+/>
+```
+
+**Props**
+
+| Prop        | Default     | Required | Type     | Description                                                                                              |
+|-------------|-------------|----------|----------|----------------------------------------------------------------------------------------------------------|
+| className   | ''          | No       | string   | Class name for the media picker container.                                                               |
+| onReset     |             | Yes      | function | Function to reset the video ID to 0 and/or the video URL to an empty string.                             |
+| onUpdate    |             | Yes      | function | Function to set the video ID on video selection/upload.                                                  |
+| onUpdateURL | null        | No       | function | Function to set the video URL on entry. If not set, the button to enter a URL manually will not display. |
+| value       |             | Yes      | integer  | The ID of the selected video. 0 represents no selection.                                                 |
+| valueURL    | ''          | No       | string   | The URL of the video. An empty string represents no selection.                                           |
+
+---
+
+## Hooks
+
+Hooks are custom React hooks that provide various functionalities within the block editor.
+
+### useBlockName
+
+A custom React hook that returns the name of a block.
+
+**Usage**
+
+```jsx
+const MyBlock = ({ clientId }) => {
+  const blockName = useBlockName(clientId);
+
+  ...
+};
+```
+
+```jsx
+const MyBlock = ({ clientId }) => {
+  const parentBlockClientId = useParentClientId(clientId);
+  const parentBlockName = useBlockName(parentBlockClientId);
+  ...
+};
+```
+
+### useCurrentPostId
+
+A custom React hook to retrieve the current post ID.
+
+**Usage**
+
+```jsx
+const MyBlock = () => {
+  const currentPostID = useCurrentPostId();
+
+  if (currentPostID) {
+    ...
+  }
+};
+```
+
+### useDebounce
+
+A custom React hook that creates and returns a new debounced version of the passed value that will postpone its execution until after wait milliseconds have elapsed since the last time it was invoked
+
+@see <https://github.com/alleyinteractive/alley-scripts/issues/250>
+
+## Usage
+
+```jsx
+const MyComponent = () => {
+  const [value, setValue] = useState('');
+  const debouncedValue = useDebounce(value, 500);
+
+  // This value will display after 500 miliseconds
+  useEffect(() => {
+    // Kickoff Function on a delay.
+  }, [debouncedValue]);
+
+  return (
+    <>
+      <TextControl
+        label={__('Set Value', 'your-textdomain-here')}
+        onChange={(next) => setValue(next)}
+        value={value}
+      />
+    </>
+  );
+};
+```
+
+### useHasInnerBlocks
+
+A custom React hook that determines if a block has inner blocks.
+
+**Usage**
+
+```jsx
+const MyBlock = ({
+ clientId
+}) => {
+  const hasInnerBlocks = useHasInnerBlocks(clientId);
+
+  if (hasInnerBlocks) {
+    ...
+  } else {
+    ...
+  }
+
+  ...
+};
+```
+
+### useInnerBlockIndex
+
+A custom React hook that returns the current block's index relative to its siblings
+within a parent block.
+
+**Usage**
+
+```jsx
+const MyBlock = ({
+ clientId
+}) => {
+  const blockIndex = useInnerBlockIndex(clientId);
+
+  ...
+};
+```
+
+### useInnerBlocksAttributes
+
+A custom React hook that returns the current blocks' inner block's attributes.
+
+**Usage**
+
+```jsx
+const MyBlock = ({
+ clientId
+}) => {
+  const innerBlockAttributes = useInnerBlocksAttributes(clientId);
+
+  ...
+};
+```
+
+### useInnerBlocksCount
+
+A custom React hook that returns the current block's inner block count.
+
+**Usage**
+
+```jsx
+const MyBlock = ({
+ clientId
+}) => {
+  const innerBlocksCount = useInnerBlocksCount(clientId);
+
+  ...
+};
+```
+
+### useMedia
+
+A custom React hook for attachment data given an ID.
+
+**Usage**
+
+```jsx
+const MyBlock = ({
+	imageID,
+}) => {
+  const image = useMedia(imageID);
+
+  ...
+};
+```
+
+### useParentBlock
+
+A custom React hook that returns the current block's parent block.
+
+**Usage**
+
+```jsx
+const MyBlock = ({ clientId }) => {
+  const parentBlock = useParentBlock(clientId);
+
+  ...
+};
+```
+
+### useParentBlockAttributes
+
+A custom React hook that returns the current block's parent block attributes.
+
+**Usage**
+
+```jsx
+const MyBlock = ({
+ clientId
+}) => {
+  const parentBlockAttributes = useParentBlockAttributes(clientId);
+
+  ...
+};
+```
+
+### useParentClientId
+
+A custom React hook that returns the client id of the parent block of the current block.
+
+**Usage**
+
+```jsx
+const MyBlock = ({ clientId }) => {
+  const parentBlockClientId = useParentClientId(clientId);
+
+  ...
+};
+```
+
+### usePost
+
+A custom React hook to retrieve post data given a post ID and post type.
+
+**Usage**
+
+```jsx
+const MyBlock = ({
+ postID,
+}) => {
+  const post = usePost(postID, postType);
+
+  if (post) {
+    ...
+  }
+};
+```
+
+### usePostById
+
+A custom React hook to retrieve post data given only a post ID.
+If you have the post type, use `usePost` instead.
+
+**Usage**
+
+```jsx
+const MyBlock = ({
+ postID,
+}) => {
+  const post = usePostById(postID);
+
+  if (post) {
+    ...
+  }
+};
+```
+
+You can also pass a function to lookup the post type when passed the post id.
+
+```jsx
+const MyBlock = ({
+ postID,
+}) => {
+  const myCustomPostTypeLookup = (id) => (
+    myCustomPostTypeMap[id]
+  );
+
+  const post = usePostById(postID, myCustomPostTypeLookup);
+
+  if (post) {
+    ...
+  }
+};
+```
+
+This function must return a string that is the post type.
+
+### usePostMeta
+
+A custom React hook that wraps useEntityProp for working with postmeta. This
+hook is intended to reduce boilerplate code in components that need to read
+and write postmeta. By default, it operates on postmeta for the current post,
+but you can optionally pass a post type and post ID in order to get and set
+post meta for an arbitrary post.
+
+**Usage**
+
+**Editing the Current Post's Meta**
+
+```jsx
+const MyComponent = () => {
+  const [meta, setMeta] = usePostMeta();
+  const { my_meta_key: myMetaKey } = meta;
+
+  return (
+    <TextControl
+      label={__('My Meta Key', 'your-textdomain-here')}
+      onChange={(next) => setMeta({ ...meta, my_meta_key: next })}
+      value={myMetaKey}
+    />
+  );
+};
+```
+
+**Editing Another Post's Meta**
+
+```jsx
+const MyComponent = ({
+  postId,
+  postType,
+}) => {
+  const [meta, setMeta] = usePostMeta(postType, postId);
+  const { my_meta_key: myMetaKey } = meta;
+
+  return (
+    <TextControl
+      label={__('My Meta Key', 'your-textdomain-here')}
+      onChange={(next) => setMeta({ ...meta, my_meta_key: next })}
+      value={myMetaKey}
+    />
+  );
+};
+```
+
+### usePostMetaValue
+
+A custom React hook that wraps useEntityProp for working with a specific
+postmeta value. It returns the value for the specified meta key as well as a
+setter for the meta value. This hook is intended to reduce boilerplate code
+in components that need to read and write postmeta. It differs from
+usePostMeta in that it operates on a specific meta key/value pair.
+By default, it operates on postmeta for the current post, but you can
+optionally pass a post type and post ID in order to get and set post meta
+for an arbitrary post.
+
+**Usage**
+
+**Editing the Current Post's Meta**
+
+```jsx
+const MyComponent = () => {
+  const [myMetaKey, setMyMetaKey] = usePostMetaValue('my_meta_key');
+
+  return (
+    <TextControl
+      label={__('My Meta Key', 'your-textdomain-here')}
+      onChange={setMyMetaKey}
+      value={myMetaKey}
+    />
+  );
+};
+```
+
+**Editing Another Post's Meta**
+
+```jsx
+const MyComponent = ({
+  postId,
+  postType,
+}) => {
+  const [myMetaKey, setMyMetaKey] = usePostMetaValue('my_meta_key', postType, postId);
+
+  return (
+    <TextControl
+      label={__('My Meta Key', 'your-textdomain-here')}
+      onChange={setMyMetaKey}
+      value={myMetaKey}
+    />
+  );
+};
+```
+
+### usePosts
+
+A custom React hook to retrieve multiple posts' data given an array of post IDs and a single post type.
+
+**Usage**
+
+```jsx
+const MyBlock = ({
+ postIDs,
+}) => {
+  const posts = usePosts(postIDs, postType);
+
+  if (posts) {
+    ...
+  }
+};
+```
+
+### useTerms
+
+ A custom React hook that wraps useEntityProp for working with a post's terms.
+ It returns an array that contains a copy of a post's terms assigned from a
+ given taxonomy as well as a helper function that sets the terms for a given
+ post. This hook is intended to reduce boilerplate code in components that
+ need to update a post's terms. By default, it operates on terms for the
+ current post, but you can optionally pass a post type and post ID in order to
+ get and set terms for an arbitrary post.
+
+**Usage**
+
+**Editing the Current Post's Terms**
+
+```jsx
+const MyComponent = ({
+  taxonomy,
+}) => {
+  const [terms, setTerms] = useTerms(null, null, taxonomy);
+
+  return (
+    <SelectControl
+      label={__('My Terms', 'your-textdomain-here')}
+      multiple
+      onChange={(next) => setTerms(next)}
+      options={options}
+      value={terms}
+    />
+  );
+};
+```
+
+**Editing Another Post's Terms**
+
+```jsx
+const MyComponent = ({
+  postId,
+  postType,
+  taxonomy,
+}) => {
+  const [terms, setTerms] = useTerms(postType, postId, taxonomy);
+
+  return (
+    <SelectControl
+      label={__('My Terms', 'your-textdomain-here')}
+      multiple
+      onChange={(next) => setTerms(next)}
+      options={options}
+      value={terms}
+    />
+  );
+};
+```
+---
+## Services
+
+Services are utility functions that provide additional functionalities.
+
+### parseCSVFile
+
+Parses a CSV file and converts it into an array of objects.
+
+Given a File object containing CSV data, `parseCSVFile` parses the CSV and returns an array of objects that are keyed by column names. Assumes that the first row in the CSV is the name of the column. Skips empty lines and attempts to do automatic type conversion.
+
+_Parameters_
+* {File} `file` - The CSV file object.
+
+_Returns_
+* {Promise} - A Promise that will resolve to an array of row objects.
+
+### getMediaUrl
+
+Extracts the URL for a media item at a requested size from a media object.
+
+Given a media object returned from the WordPress REST API, extracts the URL for the media item at the requested size if it exists, or the full size if it does not. Returns an empty string if unable to find either. Uses a superset of the same logic that the Gutenberg Image component uses for selecting the correct image size from a media REST API response.
+
+_Parameters_
+* {object} `media` - A media object returned by the WordPress API.
+* {string} `size` - Media size to request. Default: full
+
+_Returns_
+* {string} - The URL to the asset, or an empty string on failure.
+
+---
 
 ## Changelog
 

--- a/packages/block-editor-tools/README.md
+++ b/packages/block-editor-tools/README.md
@@ -40,7 +40,7 @@ Below is the documentation for all available components, hooks, and services.
 
 React components that can be used within the WordPress block editor.
 
-### [AudioPicker](src/components/audio-picker/)
+### AudioPicker
 
 Allows a user to select or remove audio using the media modal or via direct
 URL entry. This component is a thin wrapper around `MediaPicker` and sets the

--- a/packages/block-editor-tools/package.json
+++ b/packages/block-editor-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alleyinteractive/block-editor-tools",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A set of tools to help build products for the WordPress block editor.",
   "main": "./build/index.bundle.min.js",
   "types": "./build/index.d.ts",

--- a/packages/block-editor-tools/src/components/csv-uploader/README.md
+++ b/packages/block-editor-tools/src/components/csv-uploader/README.md
@@ -7,12 +7,13 @@ Allows a user to upload a CSV file, which is parsed in the browser, converted to
 ### Usage
 
 Render a CSV upload component with a callback to further process the JSON data.
-
-    <CSVUploader
-      attributeName="data"
-      callback={transformData}
-      setAttributes={setAttributes}
-    /> 
+```js
+<CSVUploader
+  attributeName="data"
+  callback={transformData}
+  setAttributes={setAttributes}
+/>
+```
 
 ### Callback Function
 
@@ -21,66 +22,18 @@ The callback function is optional, and allows for further processing of the data
 The callback function accepts an array of objects as its only parameter. Each object will be a description of one row in the CSV, with keys matching the headers in the file.
 
 Given a CSV file in the following format:
-
-    title,slug,description
-    Sample Title,sample-title,Lorem ipsum dolor sit amet.
-    
+```csv
+title,slug,description
+Sample Title,sample-title,Lorem ipsum dolor sit amet.
+```
 The array of objects passed to the callback function will take the following form:
-
-    [
-      {
-        title: 'Sample Title',
-        slug: 'sample-title',
-        description: 'Lorem ipsum dolor sit amet.',
-      },
-    ]
-    
+```js
+[
+  {
+    title: 'Sample Title',
+    slug: 'sample-title',
+    description: 'Lorem ipsum dolor sit amet.',
+  },
+]
+```
 Under the hood, the CSV parser uses PapaParse and attempts to make intelligent choices about data formats based on data in each column. Columns of integers should come through as integers, for example.
-
-It is recommended to put the callback function in the `services/data` directory with a corresponding test.
-
-### Sanitization
-
-When registering the meta field using `register_meta_helper`, you will need to provide a `sanitize_callback` in the fourth parameter pointing to a function that is able to validate and sanitize the data as it comes in.
-
-For example:
-
-    register_meta_helper(
-        'post',
-        [
-            'my-post-type',
-        ],
-        'wp_starter_plugin_csv_data',
-        [
-            'sanitize_callback' => __NAMESPACE__ . '\sanitize_csv_data',
-        ]
-    );
-
-You should put the sanitization function in `inc/meta.php`:
-
-    /**
-     * A 'sanitize_callback' for the csv_data meta field.
-     *
-     * @param mixed $meta_value Meta value to sanitize.
-     * @return string Sanitized meta value.
-     */
-    function sanitize_csv_data( $meta_value ) : string {
-
-        // The meta value should be a stringified JSON array. Ensure that it is.
-        $raw_meta_value = json_decode( $meta_value, true );
-        if ( ! is_array( $raw_meta_value ) ) {
-            return '';
-        }
-
-        // Rebuild the data, sanitizing values, and validating keys.
-        $sanitized_meta_value = [];
-        foreach ( $raw_meta_value as $row ) {
-            $sanitized_meta_value[] = [
-                'title' => sanitize_text_field( $row['title'] ?? '' ),
-                'slug' => sanitize_title( $row['slug'] ?? '' ),
-                'description' => sanitize_text_field( $row['description'] ?? '' ),
-            ];
-        }
-        
-        return wp_json_encode( $sanitized_meta_value );
-    }

--- a/plugin/.eslintrc.json
+++ b/plugin/.eslintrc.json
@@ -1,6 +1,8 @@
 {
+  "root": true,
   "extends": ["@alleyinteractive/eslint-config/typescript-react"],
-  "settings": {
-    "import/resolver": "webpack"
+  "parserOptions": {
+    "project": "tsconfig.eslint.json",
+    "tsconfigRootDir": "./"
   }
 }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -55,9 +55,9 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@alleyinteractive/eslint-config": "^0.1.0",
-    "@alleyinteractive/stylelint-config": "^0.0.2",
-    "@alleyinteractive/tsconfig": "^0.1.0",
+    "@alleyinteractive/eslint-config": "*",
+    "@alleyinteractive/stylelint-config": "*",
+    "@alleyinteractive/tsconfig": "*",
     "@babel/preset-env": "^7.23.2",
     "@types/wordpress__edit-post": "^7.0.1",
     "@types/wordpress__plugins": "^3.0.0",

--- a/plugin/tsconfig.eslint.json
+++ b/plugin/tsconfig.eslint.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+  },
+  "include": [
+    "./entries",
+    "./babel.config.js",
+    "./jest.config.js",
+    "./webpack.config.js"
+  ]
+}


### PR DESCRIPTION
### Related Issue
Related to Issue #499

### Description of the Change
This PR adds all available components, hooks, and services READMEs to the root README so it can be accessible in the published NPM package.

- [x] Update the README.md for `block-editor-tools` to include all available components, hooks, and services.
- [x] Ensure there is a centralized documentation available in the root README
- [x] Follow the format similar to WordPress API docs in READMEs.

### Additional Information
Please refer to the example of WordPress package API docs here: https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor#api

### Checklist:

- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings or errors.
- [ ] I have added tests to cover my changes. (unnecessary, documentation changes only)

#### Link to README in this PR:

https://github.com/alleyinteractive/alley-scripts/blob/c84cd840f1758f04c92c87729a7dc60e0723a3e7/packages/block-editor-tools/README.md
