### PR TITLE
Allow scaffolder discovery from installed NPM modules

### DIFF
--- a/packages/scaffolder/__tests__/fixtures/sources/.scaffolder/config.yml
+++ b/packages/scaffolder/__tests__/fixtures/sources/.scaffolder/config.yml
@@ -1,0 +1,2 @@
+sources:
+  - ../a-features

--- a/packages/scaffolder/src/configuration/store.spec.ts
+++ b/packages/scaffolder/src/configuration/store.spec.ts
@@ -1,0 +1,30 @@
+import path from 'node:path';
+
+import { getGlobalDirectory } from './globalDirectory';
+import { ConfigurationStore } from './store';
+
+describe('configuration/store', () => {
+  it('should be able to load the global configuration by default', () => {
+    const store = new ConfigurationStore();
+    store.loadFromPath(__dirname);
+
+    expect(store.all()).toEqual({
+      [`${getGlobalDirectory()}`]: expect.anything(),
+    });
+  });
+
+  it('should be able to load sources from a path', () => {
+    const sourcePath = path.resolve(__dirname, '../../__tests__/fixtures/sources');
+    const store = new ConfigurationStore();
+    store.loadFromPath(sourcePath);
+
+    expect(store.all()).toEqual({
+      [`${sourcePath}/.scaffolder`]: expect.anything(),
+      [`${getGlobalDirectory()}`]: expect.anything(),
+    });
+
+    expect(store.pluck('sources')[`${sourcePath}/.scaffolder`]).toEqual([
+      '../a-features',
+    ]);
+  });
+});

--- a/packages/scaffolder/src/configuration/store.ts
+++ b/packages/scaffolder/src/configuration/store.ts
@@ -96,6 +96,15 @@ export class ConfigurationStore {
       }
     }
 
+    this.ensureGlobalConfigurationLoaded();
+
+    logger().debug(`Loaded ${chalk.blue(Object.keys(this.configurations).length)} configurations.`);
+  }
+
+  /**
+   * Ensure the global configuration is always loaded.
+   */
+  private ensureGlobalConfigurationLoaded() {
     const globalConfigurationDirectory = getGlobalDirectory();
 
     // Ensure the global configuration is loaded if it wasn't already.
@@ -118,8 +127,6 @@ export class ConfigurationStore {
 
       logger().debug(`Loaded global configuration from ${chalk.blue(globalConfigurationDirectory)}`);
     }
-
-    logger().debug(`Loaded ${chalk.blue(Object.keys(this.configurations).length)} configurations.`);
   }
 }
 

--- a/packages/scaffolder/src/configuration/store.ts
+++ b/packages/scaffolder/src/configuration/store.ts
@@ -69,17 +69,17 @@ export class ConfigurationStore {
     let currentDirectory = directory;
 
     while (true) { // eslint-disable-line no-constant-condition
-      if (fs.existsSync(`${currentDirectory}/.scaffolder`)) {
+      if (fs.existsSync(path.join(currentDirectory, '.scaffolder'))) {
         try {
-          const configuration = fs.existsSync(`${currentDirectory}/.scaffolder/config.yml`)
-            ? (parseYamlFile(`${currentDirectory}/.scaffolder/config.yml`) || {})
+          const configuration = fs.existsSync(path.join(currentDirectory, '.scaffolder', 'config.yml'))
+            ? (parseYamlFile(path.join(currentDirectory, '.scaffolder', 'config.yml')) || {})
             : {};
 
           validateConfiguration(configuration);
 
-          this.add(`${currentDirectory}/.scaffolder`, configuration);
+          this.add(path.join(currentDirectory, '.scaffolder'), configuration);
         } catch (error: any) {
-          logger().error(`Error loading configuration from ${chalk.yellow(`${currentDirectory}/.scaffolder/config.yml`)}: ${chalk.red(error.message)}`);
+          logger().error(`Error loading configuration from ${chalk.yellow(path.join(currentDirectory, '.scaffolder', 'config.yml'))}: ${chalk.red(error.message)}`);
         }
       }
 
@@ -110,8 +110,8 @@ export class ConfigurationStore {
     // Ensure the global configuration is loaded if it wasn't already.
     if (typeof this.configurations[globalConfigurationDirectory] === 'undefined') {
       try {
-        const globalConfiguration = fs.existsSync(`${globalConfigurationDirectory}/config.yml`)
-          ? (parseYamlFile(`${globalConfigurationDirectory}/config.yml`) || {})
+        const globalConfiguration = fs.existsSync(path.join(globalConfigurationDirectory, 'config.yml'))
+          ? (parseYamlFile(path.join(globalConfigurationDirectory, 'config.yml')) || {})
           : {};
 
         try {
@@ -119,7 +119,7 @@ export class ConfigurationStore {
 
           this.add(globalConfigurationDirectory, globalConfiguration);
         } catch (error: any) {
-          logger().error(`Error loading global configuration from ${chalk.yellow(`${globalConfigurationDirectory}/config.yml`)}: ${chalk.red(error.message)}`);
+          logger().error(`Error loading global configuration from ${chalk.yellow(path.join(globalConfigurationDirectory, 'config.yml'))}: ${chalk.red(error.message)}`);
         }
       } catch (error: any) {
         logger().error(`Error loading global configuration: ${chalk.red(error.message)}`);

--- a/packages/scaffolder/src/features/store.spec.ts
+++ b/packages/scaffolder/src/features/store.spec.ts
@@ -1,0 +1,36 @@
+import path from 'path';
+import { ConfigurationStore } from '../configuration/store';
+import { FeatureStore } from './store';
+
+describe('features/store', () => {
+  const fixturesPath = path.resolve(__dirname, '../../__tests__/fixtures');
+
+  const configStore = new ConfigurationStore();
+  configStore.add(__dirname, {
+    sources: [{
+      directory: `${fixturesPath}/a-features`,
+    }],
+    features: [{
+      name: 'manually-configured-feature',
+      type: 'file',
+    }],
+  });
+
+  it('should be able to load features', async () => {
+    const store = new FeatureStore(configStore);
+    await store.initialize();
+
+    const items = store.all();
+
+    expect(Object.keys(items)).toEqual([
+      __dirname,
+      `${fixturesPath}/a-features/feature-a`,
+      `${fixturesPath}/a-features/feature-b`,
+    ]);
+
+    expect(items[__dirname]).toEqual([{ // eslint-disable-line no-underscore-dangle
+      name: 'manually-configured-feature',
+      type: 'file',
+    }]);
+  });
+});

--- a/packages/scaffolder/src/generators/generator.ts
+++ b/packages/scaffolder/src/generators/generator.ts
@@ -125,7 +125,7 @@ export abstract class Generator {
     // .scaffolder/<feature>/config.yml so we need to resolve the destination
     // based on the parent directory of the .scaffolder
     if (destinationResolver === 'relative-parent') {
-      const [parentDirectory] = this.path.split('/.scaffolder');
+      const [parentDirectory] = this.path.split(`${path.sep}.scaffolder`);
 
       return path.resolve(parentDirectory, filePath);
     }


### PR DESCRIPTION
Allows for packages to be installed that define their own scaffolder configuration. The use case here is to roll our scaffolder generations for most things (plugins/themes/etc.) into a standalone NPM package that isn't apart of `@alleyinteractive/scaffolder`.

Adds tests for both stores.

Fixes #551