### PR TITLE
Issue-582: Provide fast refresh when developing for scripts in package plugin

### DIFF
--- a/.changeset/blue-papayas-flash.md
+++ b/.changeset/blue-papayas-flash.md
@@ -1,0 +1,5 @@
+---
+"alley-scripts-demo-plugin": patch
+---
+
+Add support and documentation for fast refresh in demo plugin"

--- a/package-lock.json
+++ b/package-lock.json
@@ -37241,7 +37241,7 @@
     },
     "packages/block-editor-tools": {
       "name": "@alleyinteractive/block-editor-tools",
-      "version": "0.6.4",
+      "version": "0.7.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@alleyinteractive/eslint-config": "*",
@@ -38179,7 +38179,7 @@
     },
     "plugin": {
       "name": "alley-scripts-demo-plugin",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -20,4 +20,4 @@ To develop the plugin and see changes in real-time:
 
 ### Testing new features in the alley scripts plugin
 If you want to test any new components or hooks in a block in the plugin you can scaffold a new block, entry, or slotfill in the `alley-scripts/plugin` directory.
-To test the new feature with fast refresh be sure to import the scripts using a _relative path_ so that the development server can watch for changes. You may need to disable the [ESLint no relative packages rule (`import/no-relative-packages`)](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-relative-packages.md) to allow linting to pass. Follow the instructions above to see the changes apply in real time in the editor.
+To test the new feature with fast refresh, be sure to import the scripts using a _relative path_ so that the development server can watch for changes. You may need to disable the [ESLint no relative packages rule (`import/no-relative-packages`)](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-relative-packages.md) to allow linting to pass. Follow the instructions above to see the changes apply in real time in the editor.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,5 +1,23 @@
 # Alley Scripts Demo Plugin
 
-This is a demo plugin for Alley Scripts. It is a simple plugin that adds the
-components included in the Monorepo to a Gutenberg sidebar. It is not meant to
+This is a demo plugin for Alley Scripts. It is meant to be used in development and to
+demo the functionality of the packages in alley-scripts.
+
+The plugin adds components included in the Monorepo to a Gutenberg sidebar. It is not meant to
 be used in production.
+
+## Installation
+
+1. Clone the `alley-scripts` repository to your `plugins` directory in your local WordPress installation.
+2. Run `npm install` in the `alley-scripts` directory. Then run `npm run build` to build the plugin.
+3. Activate the plugin in your WordPress installation to see the components in the Gutenberg sidebar.
+
+## Development for block editor tools with fast refresh.
+To develop the plugin and see changes in real-time:
+1. Install the Gutenberg plugin in your WordPress installation.
+2. Ensure that `define( 'SCRIPT_DEBUG', true );` is defined in your `wp-config.php` file.
+1. Run `npm run start:hot` in the `alley-scripts/plugin` directory. This will start a development server and watch for changes in the block-editor-tools package files.
+
+### Testing new features in the alley scripts plugin
+If you want to test any new components or hooks in a block in the plugin you can scaffold a new block, entry, or slotfill in the `alley-scripts/plugin` directory.
+To test the new feature with fast refresh be sure to import the scripts using a relative path so that the development server can watch for changes. Follow the instructions above to see the changes apply in real time in the editor.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -20,4 +20,4 @@ To develop the plugin and see changes in real-time:
 
 ### Testing new features in the alley scripts plugin
 If you want to test any new components or hooks in a block in the plugin you can scaffold a new block, entry, or slotfill in the `alley-scripts/plugin` directory.
-To test the new feature with fast refresh be sure to import the scripts using a relative path so that the development server can watch for changes. Follow the instructions above to see the changes apply in real time in the editor.
+To test the new feature with fast refresh be sure to import the scripts using a _relative path_ so that the development server can watch for changes. You may need to disable the [ESLint no relative packages rule (`import/no-relative-packages`)](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-relative-packages.md) to allow linting to pass. Follow the instructions above to see the changes apply in real time in the editor.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -14,7 +14,7 @@ be used in production.
 
 ## Development for block editor tools with fast refresh.
 To develop the plugin and see changes in real-time:
-1. Install the Gutenberg plugin in your WordPress installation.
+1. Install the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/) in your WordPress installation.
 2. Ensure that `define( 'SCRIPT_DEBUG', true );` is defined in your `wp-config.php` file.
 1. Run `npm run start:hot` in the `alley-scripts/plugin` directory. This will start a development server and watch for changes in the block-editor-tools package files.
 

--- a/plugin/entries/slotfills/index.tsx
+++ b/plugin/entries/slotfills/index.tsx
@@ -20,8 +20,14 @@ import {
   PostSelector,
   TermSelector,
   usePostMeta,
-// Importing the relative path so that when developing in the watch mode in the plugin,
-// block-editor-tools will rebuild.
+/**
+ * Importing the relative path so that when developing in the watch mode,
+ * the block-editor-tools will rebuild. This is necessary as the block-editor-tools
+ * need to be built and compiled before the plugin can be built and compiled.
+ *
+ * https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-relative-packages.md
+ */
+// eslint-disable-next-line import/no-relative-packages
 } from '../../../packages/block-editor-tools/src';
 
 // Create a new Gutenberg sidebar

--- a/plugin/entries/slotfills/index.tsx
+++ b/plugin/entries/slotfills/index.tsx
@@ -20,7 +20,9 @@ import {
   PostSelector,
   TermSelector,
   usePostMeta,
-} from '@alleyinteractive/block-editor-tools';
+// Importing the relative path so that when developing in the watch mode in the plugin,
+// block-editor-tools will rebuild.
+} from '../../../packages/block-editor-tools/src';
 
 // Create a new Gutenberg sidebar
 registerPlugin('alley-scripts-plugin-sidebar', {


### PR DESCRIPTION
### Description

I would like to be able to run dev mode in any of the `alley-scripts/packages/*` while also running dev mode in the `alley-scripts/plugin` so that I can work on the scripts without having to run `npm run build` and refresh the page in order to see the changes.

Documentation also needs to be provided in order for developers to properly get set up to develop in the plugin accordingly.

### Use Case

Example:
In the directory `alley-scripts/packages/block-editor-tools` run `npm run dev` in the command line to run  Webpack development mode with the watch flag so that the files will recompile whenever they change. `webpack --mode=development --watch`.

Simultaneously in the `alley-scripts/plugin` directory I want to run `npm run dev` or `npm run start` while importing or linking with npm link the `block-editor-tools` to see my changes when the files change.

**By using a relative path import to the development plugin we can allow for fast refresh when developing in packages such as the block editor tools.**

Related issue: [Provide fast refresh when developing for scripts in package plugin](https://github.com/alleyinteractive/alley-scripts/issues/582)
