### PR TITLE
Enhancement: Update `create-block` templates to scaffold optional view script

### DIFF
--- a/.changeset/old-emus-destroy.md
+++ b/.changeset/old-emus-destroy.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/create-block": minor
+---
+
+Allow users to opt-in to scaffolding a view script

--- a/package-lock.json
+++ b/package-lock.json
@@ -22790,14 +22790,15 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -38036,7 +38037,7 @@
     },
     "packages/scaffolder": {
       "name": "@alleyinteractive/scaffolder",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@alleyinteractive/scaffolder-features": "*",
@@ -38180,7 +38181,7 @@
     },
     "plugin": {
       "name": "alley-scripts-demo-plugin",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -53714,7 +53715,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.15.5"
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14207,117 +14207,6 @@
       "version": "2.1.0",
       "license": "MIT"
     },
-    "node_modules/@wordpress/create-block": {
-      "version": "4.32.0",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/lazy-import": "^1.35.0",
-        "chalk": "^4.0.0",
-        "change-case": "^4.1.2",
-        "check-node-version": "^4.1.0",
-        "commander": "^9.2.0",
-        "execa": "^4.0.2",
-        "fast-glob": "^3.2.7",
-        "inquirer": "^7.1.0",
-        "make-dir": "^3.0.0",
-        "mustache": "^4.0.0",
-        "npm-package-arg": "^8.1.5",
-        "rimraf": "^3.0.2",
-        "write-pkg": "^4.0.0"
-      },
-      "bin": {
-        "wp-create-block": "index.js"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.14.4"
-      }
-    },
-    "node_modules/@wordpress/create-block/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@wordpress/create-block/node_modules/chalk": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@wordpress/create-block/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@wordpress/create-block/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/@wordpress/create-block/node_modules/commander": {
-      "version": "9.5.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/@wordpress/create-block/node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wordpress/create-block/node_modules/make-dir": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/create-block/node_modules/semver": {
-      "version": "6.3.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@wordpress/create-block/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@wordpress/data": {
       "version": "9.15.0",
       "license": "GPL-2.0-or-later",
@@ -16120,26 +16009,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/make-dir": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/p-limit": {
@@ -19096,6 +18965,14 @@
       "version": "0.1.2",
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/comment-parser": {
       "version": "1.4.1",
       "license": "MIT",
@@ -19246,26 +19123,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/configstore/node_modules/make-dir": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/configstore/node_modules/semver": {
-      "version": "6.3.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/configstore/node_modules/write-file-atomic": {
@@ -22598,26 +22455,6 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
-    "node_modules/find-cache-dir/node_modules/make-dir": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/find-file-up": {
       "version": "0.1.3",
       "license": "MIT",
@@ -25190,26 +25027,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/make-dir": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/semver": {
-      "version": "6.3.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
@@ -27960,6 +27777,28 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -37428,12 +37267,84 @@
         "@wordpress/scripts": "*"
       }
     },
+    "packages/create-block/node_modules/@wordpress/create-block": {
+      "version": "4.26.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.26.13.tgz",
+      "integrity": "sha512-ZX3nSU8nTyo4a56QFS62uAO4PNWwXMmmJaROlKxDJeWD8ueJ/29omaw9PM0npZJFVcQiyOM8KkLAB+P04ct1QQ==",
+      "dependencies": {
+        "@wordpress/lazy-import": "^1.29.13",
+        "chalk": "^4.0.0",
+        "change-case": "^4.1.2",
+        "check-node-version": "^4.1.0",
+        "commander": "^9.2.0",
+        "execa": "^4.0.2",
+        "fast-glob": "^3.2.7",
+        "inquirer": "^7.1.0",
+        "make-dir": "^3.0.0",
+        "mustache": "^4.0.0",
+        "npm-package-arg": "^8.1.5",
+        "rimraf": "^3.0.2",
+        "write-pkg": "^4.0.0"
+      },
+      "bin": {
+        "wp-create-block": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.14.4"
+      }
+    },
+    "packages/create-block/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "packages/create-block/node_modules/array-back": {
       "version": "6.2.2",
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
       }
+    },
+    "packages/create-block/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/create-block/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "packages/create-block/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "packages/create-block/node_modules/command-line-usage": {
       "version": "7.0.1",
@@ -37446,6 +37357,25 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "packages/create-block/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/create-block/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/create-block/node_modules/table-layout": {
@@ -38428,8 +38358,58 @@
         "prompts": "^2.4.2"
       },
       "dependencies": {
+        "@wordpress/create-block": {
+          "version": "4.26.13",
+          "resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.26.13.tgz",
+          "integrity": "sha512-ZX3nSU8nTyo4a56QFS62uAO4PNWwXMmmJaROlKxDJeWD8ueJ/29omaw9PM0npZJFVcQiyOM8KkLAB+P04ct1QQ==",
+          "requires": {
+            "@wordpress/lazy-import": "^1.29.13",
+            "chalk": "^4.0.0",
+            "change-case": "^4.1.2",
+            "check-node-version": "^4.1.0",
+            "commander": "^9.2.0",
+            "execa": "^4.0.2",
+            "fast-glob": "^3.2.7",
+            "inquirer": "^7.1.0",
+            "make-dir": "^3.0.0",
+            "mustache": "^4.0.0",
+            "npm-package-arg": "^8.1.5",
+            "rimraf": "^3.0.2",
+            "write-pkg": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "array-back": {
           "version": "6.2.2"
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "command-line-usage": {
           "version": "7.0.1",
@@ -38438,6 +38418,19 @@
             "chalk-template": "^0.4.0",
             "table-layout": "^3.0.0",
             "typical": "^7.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         },
         "table-layout": {
@@ -48100,69 +48093,6 @@
         }
       }
     },
-    "@wordpress/create-block": {
-      "version": "4.32.0",
-      "requires": {
-        "@wordpress/lazy-import": "^1.35.0",
-        "chalk": "^4.0.0",
-        "change-case": "^4.1.2",
-        "check-node-version": "^4.1.0",
-        "commander": "^9.2.0",
-        "execa": "^4.0.2",
-        "fast-glob": "^3.2.7",
-        "inquirer": "^7.1.0",
-        "make-dir": "^3.0.0",
-        "mustache": "^4.0.0",
-        "npm-package-arg": "^8.1.5",
-        "rimraf": "^3.0.2",
-        "write-pkg": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4"
-        },
-        "commander": {
-          "version": "9.5.0"
-        },
-        "has-flag": {
-          "version": "4.0.0"
-        },
-        "make-dir": {
-          "version": "3.1.0",
-          "requires": {
-            "semver": "^6.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.1"
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "@wordpress/data": {
       "version": "9.15.0",
       "requires": {
@@ -49399,17 +49329,6 @@
           "version": "6.0.0",
           "requires": {
             "yallist": "^4.0.0"
-          }
-        },
-        "make-dir": {
-          "version": "3.1.0",
-          "requires": {
-            "semver": "^6.0.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.1"
-            }
           }
         },
         "p-limit": {
@@ -51330,6 +51249,11 @@
     "command-score": {
       "version": "0.1.2"
     },
+    "commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
+    },
     "comment-parser": {
       "version": "1.4.1"
     },
@@ -51451,15 +51375,6 @@
         "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
-        "make-dir": {
-          "version": "3.1.0",
-          "requires": {
-            "semver": "^6.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.1"
-        },
         "write-file-atomic": {
           "version": "3.0.3",
           "requires": {
@@ -53595,17 +53510,6 @@
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
         "pkg-dir": "^4.1.0"
-      },
-      "dependencies": {
-        "make-dir": {
-          "version": "3.1.0",
-          "requires": {
-            "semver": "^6.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.1"
-        }
       }
     },
     "find-file-up": {
@@ -55194,15 +55098,6 @@
       "dependencies": {
         "has-flag": {
           "version": "4.0.0"
-        },
-        "make-dir": {
-          "version": "3.1.0",
-          "requires": {
-            "semver": "^6.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.1"
         },
         "supports-color": {
           "version": "7.2.0",
@@ -56912,6 +56807,21 @@
       "dev": true,
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.4.13"
+      }
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+        }
       }
     },
     "make-error": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14207,6 +14207,97 @@
       "version": "2.1.0",
       "license": "MIT"
     },
+    "node_modules/@wordpress/create-block": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.37.0.tgz",
+      "integrity": "sha512-ViZpYDDXWQzW3uRdYLmLFI5/TXO1FESqqIRurDAOqxfOT8hQp5D9YfcOQNRgHJ/3Ac3ZcSHnA+SPPXCtg6omEQ==",
+      "dependencies": {
+        "@wordpress/lazy-import": "^1.40.0",
+        "chalk": "^4.0.0",
+        "change-case": "^4.1.2",
+        "check-node-version": "^4.1.0",
+        "commander": "^9.2.0",
+        "execa": "^4.0.2",
+        "fast-glob": "^3.2.7",
+        "inquirer": "^7.1.0",
+        "make-dir": "^3.0.0",
+        "mustache": "^4.0.0",
+        "npm-package-arg": "^8.1.5",
+        "rimraf": "^3.0.2",
+        "write-pkg": "^4.0.0"
+      },
+      "bin": {
+        "wp-create-block": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.14.4"
+      }
+    },
+    "node_modules/@wordpress/create-block/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@wordpress/create-block/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@wordpress/create-block/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@wordpress/create-block/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@wordpress/create-block/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wordpress/create-block/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@wordpress/data": {
       "version": "9.15.0",
       "license": "GPL-2.0-or-later",
@@ -14966,8 +15057,9 @@
       }
     },
     "node_modules/@wordpress/lazy-import": {
-      "version": "1.35.0",
-      "license": "GPL-2.0-or-later",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/lazy-import/-/lazy-import-1.40.0.tgz",
+      "integrity": "sha512-k1hNo0x6rDMuce1Z9JGN/7KjGa4FKlUGnodlUR3ftyp+VzxLTN/FStdxHyT4Ebu1rPWGwJRLNlgDZcccn7X2cw==",
       "dependencies": {
         "execa": "^4.0.2",
         "npm-package-arg": "^8.1.5",
@@ -14979,7 +15071,8 @@
     },
     "node_modules/@wordpress/lazy-import/node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14988,8 +15081,9 @@
       }
     },
     "node_modules/@wordpress/lazy-import/node_modules/semver": {
-      "version": "7.5.4",
-      "license": "ISC",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -15002,7 +15096,8 @@
     },
     "node_modules/@wordpress/lazy-import/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@wordpress/media-utils": {
       "version": "4.36.0",
@@ -37267,84 +37362,12 @@
         "@wordpress/scripts": "*"
       }
     },
-    "packages/create-block/node_modules/@wordpress/create-block": {
-      "version": "4.26.13",
-      "resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.26.13.tgz",
-      "integrity": "sha512-ZX3nSU8nTyo4a56QFS62uAO4PNWwXMmmJaROlKxDJeWD8ueJ/29omaw9PM0npZJFVcQiyOM8KkLAB+P04ct1QQ==",
-      "dependencies": {
-        "@wordpress/lazy-import": "^1.29.13",
-        "chalk": "^4.0.0",
-        "change-case": "^4.1.2",
-        "check-node-version": "^4.1.0",
-        "commander": "^9.2.0",
-        "execa": "^4.0.2",
-        "fast-glob": "^3.2.7",
-        "inquirer": "^7.1.0",
-        "make-dir": "^3.0.0",
-        "mustache": "^4.0.0",
-        "npm-package-arg": "^8.1.5",
-        "rimraf": "^3.0.2",
-        "write-pkg": "^4.0.0"
-      },
-      "bin": {
-        "wp-create-block": "index.js"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.14.4"
-      }
-    },
-    "packages/create-block/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "packages/create-block/node_modules/array-back": {
       "version": "6.2.2",
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
       }
-    },
-    "packages/create-block/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/create-block/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "packages/create-block/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "packages/create-block/node_modules/command-line-usage": {
       "version": "7.0.1",
@@ -37357,25 +37380,6 @@
       },
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "packages/create-block/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/create-block/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "packages/create-block/node_modules/table-layout": {
@@ -38358,58 +38362,8 @@
         "prompts": "^2.4.2"
       },
       "dependencies": {
-        "@wordpress/create-block": {
-          "version": "4.26.13",
-          "resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.26.13.tgz",
-          "integrity": "sha512-ZX3nSU8nTyo4a56QFS62uAO4PNWwXMmmJaROlKxDJeWD8ueJ/29omaw9PM0npZJFVcQiyOM8KkLAB+P04ct1QQ==",
-          "requires": {
-            "@wordpress/lazy-import": "^1.29.13",
-            "chalk": "^4.0.0",
-            "change-case": "^4.1.2",
-            "check-node-version": "^4.1.0",
-            "commander": "^9.2.0",
-            "execa": "^4.0.2",
-            "fast-glob": "^3.2.7",
-            "inquirer": "^7.1.0",
-            "make-dir": "^3.0.0",
-            "mustache": "^4.0.0",
-            "npm-package-arg": "^8.1.5",
-            "rimraf": "^3.0.2",
-            "write-pkg": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "array-back": {
           "version": "6.2.2"
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "command-line-usage": {
           "version": "7.0.1",
@@ -38418,19 +38372,6 @@
             "chalk-template": "^0.4.0",
             "table-layout": "^3.0.0",
             "typical": "^7.1.1"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         },
         "table-layout": {
@@ -48093,6 +48034,71 @@
         }
       }
     },
+    "@wordpress/create-block": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.37.0.tgz",
+      "integrity": "sha512-ViZpYDDXWQzW3uRdYLmLFI5/TXO1FESqqIRurDAOqxfOT8hQp5D9YfcOQNRgHJ/3Ac3ZcSHnA+SPPXCtg6omEQ==",
+      "requires": {
+        "@wordpress/lazy-import": "^1.40.0",
+        "chalk": "^4.0.0",
+        "change-case": "^4.1.2",
+        "check-node-version": "^4.1.0",
+        "commander": "^9.2.0",
+        "execa": "^4.0.2",
+        "fast-glob": "^3.2.7",
+        "inquirer": "^7.1.0",
+        "make-dir": "^3.0.0",
+        "mustache": "^4.0.0",
+        "npm-package-arg": "^8.1.5",
+        "rimraf": "^3.0.2",
+        "write-pkg": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@wordpress/data": {
       "version": "9.15.0",
       "requires": {
@@ -48650,7 +48656,9 @@
       }
     },
     "@wordpress/lazy-import": {
-      "version": "1.35.0",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/lazy-import/-/lazy-import-1.40.0.tgz",
+      "integrity": "sha512-k1hNo0x6rDMuce1Z9JGN/7KjGa4FKlUGnodlUR3ftyp+VzxLTN/FStdxHyT4Ebu1rPWGwJRLNlgDZcccn7X2cw==",
       "requires": {
         "execa": "^4.0.2",
         "npm-package-arg": "^8.1.5",
@@ -48659,18 +48667,24 @@
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
-          "version": "7.5.4",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },

--- a/packages/create-block/index.ts
+++ b/packages/create-block/index.ts
@@ -50,7 +50,7 @@ const options: Options[] = [
   {
     name: 'hasViewScript',
     alias: 'v',
-    description: 'Will this block have a front end view script? (default: false)',
+    description: 'Whether the block will have a frontend scripts definition. (viewScript in block.json)',
     type: Boolean,
   },
   {

--- a/packages/create-block/index.ts
+++ b/packages/create-block/index.ts
@@ -48,6 +48,12 @@ const options: Options[] = [
     type: String,
   },
   {
+    name: 'hasViewScript',
+    alias: 'v',
+    description: 'Will this block have a front end view script? (default: false)',
+    type: Boolean,
+  },
+  {
     name: 'help',
     alias: 'h',
     description: 'Display this usage guide.',
@@ -104,19 +110,29 @@ if (help) {
   // If there is no command line argument for the block language,
   // allow the user to select one with a prompt.
   if (!blockLanguage) {
-    const { blockLanguagePrompt }: {
+    const { blockLanguagePrompt, hasViewScript }: {
       blockLanguagePrompt: LanguageType;
-    } = await prompts({
-      type: 'select',
-      name: 'blockLanguagePrompt',
-      message: 'Create a block in TypeScript or JavaScript?',
-      choices: [
-        { title: 'TypeScript', value: 'typescript' },
-        { title: 'JavaScript', value: 'javascript' },
-      ],
-      initial: 0,
-    });
+      hasViewScript: boolean;
+    } = await prompts([
+      {
+        type: 'select',
+        name: 'blockLanguagePrompt',
+        message: 'Create a block in TypeScript or JavaScript?',
+        choices: [
+          { title: 'TypeScript', value: 'typescript' },
+          { title: 'JavaScript', value: 'javascript' },
+        ],
+        initial: 0,
+      },
+      {
+        type: 'confirm',
+        name: 'hasViewScript',
+        message: 'Will this block have a front end view script?',
+        initial: false,
+      },
+    ]);
     process.env.blockLanguage = validateBlockLanguage(blockLanguagePrompt);
+    process.env.hasViewScript = String(hasViewScript);
   } else {
     process.env.blockLanguage = validateBlockLanguage(blockLanguage);
   }

--- a/packages/create-block/src/selectTemplates.ts
+++ b/packages/create-block/src/selectTemplates.ts
@@ -1,9 +1,19 @@
 const path = require('path');
 
-const templateDirectory = process.env.blockLanguage || 'typescript';
+const {
+  hasViewScript = false,
+  blockLanguage = 'typescript',
+} = process.env;
+
+// The javascript or typescript script suffix or filetype based on the block language.
+const scriptSuffix: string = blockLanguage === 'typescript' ? 'ts' : 'js';
 
 // This path should be relative to the dist folder.
-const blockTemplatesPath: string = path.join(__dirname, '../../templates', templateDirectory);
+const blockTemplatesPath: string = path.join(__dirname, '../../templates', blockLanguage);
+
+const viewScript = hasViewScript === 'true' ? {
+  viewScript: [`file:view.${scriptSuffix}`],
+} : {};
 
 /**
  * Custom variants for scaffolding blocks.
@@ -26,9 +36,10 @@ module.exports = {
     description: '',
     dashicon: 'palmtree',
     category: 'widgets',
-    editorScript: 'file:index.ts',
+    editorScript: `file:index.${scriptSuffix}`,
     editorStyle: 'file:index.css',
     style: ['file:style-index.css'],
+    ...viewScript,
   },
   variants: {
     dynamic: {

--- a/packages/create-block/templates/javascript/view.js.mustache
+++ b/packages/create-block/templates/javascript/view.js.mustache
@@ -1,0 +1,15 @@
+{{#viewScript}}
+/**
+ * Use this file for JavaScript code that you want to run in the front-end 
+ * on posts/pages that contain this block.
+ *
+ * When this file is defined as the value of the `viewScript` property
+ * in `block.json` it will be enqueued on the front end of the site.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script
+ */
+
+/* eslint-disable no-console */
+console.log('Hello World! (from {{namespace}}-{{slug}} block)'');
+/* eslint-enable no-console */
+{{/viewScript}}

--- a/packages/create-block/templates/typescript/view.ts.mustache
+++ b/packages/create-block/templates/typescript/view.ts.mustache
@@ -1,0 +1,15 @@
+{{#viewScript}}
+/**
+ * Use this file for JavaScript code that you want to run in the front-end 
+ * on posts/pages that contain this block.
+ *
+ * When this file is defined as the value of the `viewScript` property
+ * in `block.json` it will be enqueued on the front end of the site.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script
+ */
+
+/* eslint-disable no-console */
+console.log('Hello World! (from {{namespace}}-{{slug}} block)');
+/* eslint-enable no-console */
+{{/viewScript}}


### PR DESCRIPTION
## Summary
The `wp-create-block` script from [@wordpress/create-block](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/) will scaffold a `viewScript` by default. This may not be necessary as many blocks do not require a view script. The result is that a stale file is scaffolded and enqueued when the developer creates a block. This may require the developer to manually remove the stale file and the block.json `viewScript` definition.

This change introduces a prompt allowing the developer to opt-in to including a [viewScript](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script) block type definition and will scaffold with the scaffolded block by prompting the developer during the Alley create-block process.

Related Issue: [#602](https://github.com/alleyinteractive/alley-scripts/issues/602)

## Changes
- Feature: Add a prompt for `hasViewScript` to determine whether a viewScript should be scaffolded.
- Feature: New scaffolded view scripts if a user opts-in to a view
- Bugfix: Use the `blocklanguage` to apply the appropriate file type to the scaffolded files.

## Test Steps
- Checkout this branch to test this new functionality.
- Run `npm install` to get all of the necessary dependencies.
- Navigate to the test plugin in alley-scripts, `alley-scripts/plugin`
- Run the `npm run create-block` command.
- You will be prompted with `"Will this block have a front end view script?"`
- The `view.ts|js` file will be scaffolded to the blocks directory'
- The `viewScript` definition will be present in the `block.json` file.

## Additional Notes
- https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#view-script
