### PR TITLE
darken hover/active state for PostPicker post list

### DIFF
--- a/packages/block-editor-tools/src/components/post-picker/post-list.scss
+++ b/packages/block-editor-tools/src/components/post-picker/post-list.scss
@@ -23,11 +23,11 @@
   }
 
   &:hover {
-    background-color: #f5f5f5;
+    background-color: #f0f0f0;
   }
 
   &.is-selected {
-    background-color: #f5f5f5;
+    background-color: #f0f0f0;
   }
 }
 


### PR DESCRIPTION
Per https://github.com/alleyinteractive/alley-scripts/issues/167:

No issues were found using the keyboard to navigate the current state of the PostPicker modal, however a subsequent Slack conversation surfaced that it's easy to overlook that a page has been selected. This PR slightly darkens that selected/hover state color, so that it's more noticeable without prompting a11y contrast concerns. (I picked this color to align with the hover states of WordPress core sidebar hover states.)