### PR TITLE
Issue-662: Add resolveJsonModule to tsconfig

### DIFF
--- a/.changeset/tiny-carrots-cheat.md
+++ b/.changeset/tiny-carrots-cheat.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/tsconfig": patch
+---
+
+Add resolveJsonModule to allow importing JSON files

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -46,6 +46,7 @@ including:
 * `outDir`: `build` - The output directory for the transpiled files.
 * `preserveWatchOutput`: `true` - Ensures that the output is cleared before
   each build.
+* `resolveJsonModule`: `true` - Allows importing JSON files as modules.
 * `skipLibCheck`: `true` - Skips type checking of `.d.ts` files.
 * `sourceMap`: `true` - Generates source maps for the transpiled files.
 * `strict`: `true` - Enables all strict type checking options.

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -18,6 +18,7 @@
     "noUnusedParameters": false,
     "outDir": "build",
     "preserveWatchOutput": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
### Summary

Fixes #662

### Description

It's a common pattern to import from JSON files, which is supported by setting resolveJsonModule to true. We should add this to the tsconfig package as a default.

### Use Case

When developing Gutenberg blocks it's common to import block.json which fails out of the box with this config.
