### PR TITLE
Prevent Direct Access to the Block's index.php file

### DIFF
--- a/packages/create-block/templates/javascript/index.php.mustache
+++ b/packages/create-block/templates/javascript/index.php.mustache
@@ -5,9 +5,7 @@
  * @package {{namespace}}
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Registers the {{namespace}}/{{slug}} block using the metadata loaded from the `block.json` file.

--- a/packages/create-block/templates/javascript/index.php.mustache
+++ b/packages/create-block/templates/javascript/index.php.mustache
@@ -5,6 +5,10 @@
  * @package {{namespace}}
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Registers the {{namespace}}/{{slug}} block using the metadata loaded from the `block.json` file.
  */

--- a/packages/create-block/templates/javascript/render.php.mustache
+++ b/packages/create-block/templates/javascript/render.php.mustache
@@ -14,9 +14,7 @@
  * @package {{namespace}}
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 ?>
 <p <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>

--- a/packages/create-block/templates/javascript/render.php.mustache
+++ b/packages/create-block/templates/javascript/render.php.mustache
@@ -14,6 +14,10 @@
  * @package {{namespace}}
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 <p <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
 	<?php esc_html_e( '{{title}} - hello from a dynamic block!' ); ?>


### PR DESCRIPTION
Handles direct requests gracefully. Exit silently rather than with a HTTP 500 error.

Closes https://github.com/alleyinteractive/alley-scripts/issues/671