### PR TITLE
Fix bug where post meta may not save

### DIFF
--- a/.changeset/slow-feet-tie.md
+++ b/.changeset/slow-feet-tie.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/block-editor-tools": patch
+---
+
+Improve stability of usePostMeta hooks

--- a/packages/block-editor-tools/src/hooks/use-post-meta-value/README.md
+++ b/packages/block-editor-tools/src/hooks/use-post-meta-value/README.md
@@ -1,47 +1,47 @@
 # Custom Hooks: usePostMetaValue
 
-A custom React hook that wraps useEntityProp for working with a specific
-postmeta value. It returns the value for the specified meta key as well as a
+A custom React hook that wraps `useEntityProp` for working with a specific post
+meta value. It returns a tuple with the value for the meta key as well as a
 setter for the meta value. This hook is intended to reduce boilerplate code
-in components that need to read and write postmeta. It differs from
-usePostMeta in that it operates on a specific meta key/value pair.
-By default, it operates on postmeta for the current post, but you can
+in components that need to read and write post meta. It differs from
+`usePostMeta` in that it operates only on one specific meta key/value pair.
+By default, it operates on post meta for the current post, but you can
 optionally pass a post type and post ID in order to get and set post meta
 for an arbitrary post.
+
+The setter function accepts either a value or an updater function, which works
+exactly like `useState`. See [the docs on `useState` for more information](https://react.dev/reference/react/useState#updating-state-based-on-the-previous-state).
 
 ## Usage
 
 ### Editing the Current Post's Meta
 
 ```jsx
-const MyComponent = () => {
-  const [myMetaKey, setMyMetaKey] = usePostMetaValue('my_meta_key');
+function MyComponent() {
+  const [value, setValue] = usePostMetaValue('my_meta_key');
 
   return (
     <TextControl
-      label={__('My Meta Key', 'your-textdomain-here')}
-      onChange={setMyMetaKey}
-      value={myMetaKey}
+      label={__('My Meta Key', 'your-textdomain')}
+      onChange={setValue}
+      value={value}
     />
   );
-};
+}
 ```
 
 ### Editing Another Post's Meta
 
 ```jsx
-const MyComponent = ({
-  postId,
-  postType,
-}) => {
-  const [myMetaKey, setMyMetaKey] = usePostMetaValue('my_meta_key', postType, postId);
+function MyComponent({ id, type = 'post' }) {
+  const [value, setValue] = usePostMetaValue('my_meta_key', type, id);
 
   return (
     <TextControl
-      label={__('My Meta Key', 'your-textdomain-here')}
-      onChange={setMyMetaKey}
-      value={myMetaKey}
+      label={__("Another Post's Meta Key", 'your-textdomain')}
+      onChange={setValue}
+      value={value}
     />
   );
-};
+}
 ```

--- a/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js
+++ b/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js
@@ -24,7 +24,7 @@ const usePostMetaValue = (metaKey, postType = null, postId = null) => {
    * responsible for.
    * @param {*} value - The value to set for the key.
    */
-  const setPostMetaValue = (value) => setMeta(metaKey, value);
+  const setPostMetaValue = (value) => setMeta({ ...meta, [metaKey]: value });
 
   return [meta[metaKey], setPostMetaValue];
 };

--- a/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js
+++ b/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js
@@ -14,7 +14,7 @@ import { usePostMeta } from '..';
  *                            Defaults to the post type of the current post.
  * @param {number} postId - Optional. The post ID to get and set meta for.
  *                          Defaults to the ID of the current post.
- * @returns {array} An array containing the post meta value and an update function.
+ * @returns {array} A tuple containing the post meta value and a setter function.
  */
 const usePostMetaValue = (metaKey, postType = null, postId = null) => {
   const [meta, setMeta] = usePostMeta(postType, postId);
@@ -22,9 +22,14 @@ const usePostMetaValue = (metaKey, postType = null, postId = null) => {
   /**
    * A helper function for setting the value for the meta key that this hook is
    * responsible for.
-   * @param {*} value - The value to set for the key.
+   * @param {*} value - The value to set for the key. Optionally, this can be a
+   *                    function that receives the current value and returns a new
+   *                    value.
    */
-  const setPostMetaValue = (value) => setMeta((oldMeta) => ({ ...oldMeta, [metaKey]: value }));
+  const setPostMetaValue = (value) => setMeta((oldMeta) => {
+    const newValue = typeof value === 'function' ? value(oldMeta[metaKey]) : value;
+    return { ...oldMeta, [metaKey]: newValue };
+  });
 
   return [meta[metaKey], setPostMetaValue];
 };

--- a/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js
+++ b/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js
@@ -24,7 +24,7 @@ const usePostMetaValue = (metaKey, postType = null, postId = null) => {
    * responsible for.
    * @param {*} value - The value to set for the key.
    */
-  const setPostMetaValue = (value) => setMeta({ ...meta, [metaKey]: value });
+  const setPostMetaValue = (value) => setMeta((oldMeta) => ({ ...oldMeta, [metaKey]: value }));
 
   return [meta[metaKey], setPostMetaValue];
 };

--- a/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js
+++ b/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js
@@ -24,7 +24,7 @@ const usePostMetaValue = (metaKey, postType = null, postId = null) => {
    * responsible for.
    * @param {*} value - The value to set for the key.
    */
-  const setPostMetaValue = (value) => setMeta({ ...meta, [metaKey]: value });
+  const setPostMetaValue = (value) => setMeta(metaKey, value);
 
   return [meta[metaKey], setPostMetaValue];
 };

--- a/packages/block-editor-tools/src/hooks/use-post-meta/README.md
+++ b/packages/block-editor-tools/src/hooks/use-post-meta/README.md
@@ -1,46 +1,84 @@
 # Custom Hooks: usePostMeta
 
-A custom React hook that wraps useEntityProp for working with postmeta. This
+A custom React hook that wraps useEntityProp for working with post meta. This
 hook is intended to reduce boilerplate code in components that need to read
-and write postmeta. By default, it operates on postmeta for the current post,
+and write post meta. By default, it operates on post meta for the current post,
 but you can optionally pass a post type and post ID in order to get and set
 post meta for an arbitrary post.
+
+This hook returns a tuple of all available post meta and a function to update
+the post meta. The setter function accepts either a full object or a function
+which receives the most up-to-date post meta. **It is advised to use the
+function form of the setter when updating post meta or else you may risk
+overwriting changes made by other components.**
+
+When working with single post meta entries, it is recommended to use
+`usePostMetaValue` instead. `usePostMeta` is best suited for components that
+need to read and write multiple post meta entries at the same time.
 
 ## Usage
 
 ### Editing the Current Post's Meta
 
 ```jsx
-const MyComponent = () => {
-  const [meta, setMeta] = usePostMeta();
-  const { my_meta_key: myMetaKey } = meta;
+function MyComponent() {
+  const [{ my_meta_key: metaValue }, setMeta] = usePostMeta();
+
+  const onChangeMeta = (value) => {
+    setMeta((old) => ({
+      ...old,
+      my_meta_key: value,
+      last_meta_key: metaValue,
+    }));
+  };
 
   return (
     <TextControl
-      label={__('My Meta Key', 'your-textdomain-here')}
-      onChange={(next) => setMeta({ ...meta, my_meta_key: next })}
-      value={myMetaKey}
+      label={__('My Meta Key', 'your-textdomain')}
+      onChange={onChangeMeta}
+      value={metaValue}
     />
   );
-};
+}
 ```
 
 ### Editing Another Post's Meta
 
 ```jsx
-const MyComponent = ({
-  postId,
-  postType,
-}) => {
-  const [meta, setMeta] = usePostMeta(postType, postId);
-  const { my_meta_key: myMetaKey } = meta;
+function MyComponent({ id, type }) {
+  const [{ my_meta_key: myMetaValue }, setMeta] = usePostMeta(type, id);
 
   return (
     <TextControl
-      label={__('My Meta Key', 'your-textdomain-here')}
-      onChange={(next) => setMeta({ ...meta, my_meta_key: next })}
-      value={myMetaKey}
+      label={__("Another Post's Meta Key", 'your-textdomain')}
+      onChange={(next) => setMeta((old) => ({ ...old, my_meta_key: next }))}
+      value={myMetaValue}
     />
   );
-};
+}
+```
+
+### Potentially Overwriting Meta
+
+This is an example of what _not_ to do, or at least what to be cautious of when
+using the `usePostMeta` setter function.
+
+Note here that the `setMeta` function updates the entire post meta object based
+on the current state of `meta` in the component. While not guaranteed, there is
+a risk that another component could update the post meta in between the time
+that `meta` is read and when `setMeta` is called. This could result in those
+changes being overwritten.
+
+```jsx
+function MyComponent() {
+  const [meta, setMeta] = usePostMeta();
+
+  return (
+    <TextControl
+      label={__('My Meta Key', 'your-textdomain')}
+      onChange={(next) => setMeta({ ...meta, my_meta_key: next })}
+      value={meta.my_meta_key}
+    />
+  );
+}
 ```

--- a/packages/block-editor-tools/src/hooks/use-post-meta/index.js
+++ b/packages/block-editor-tools/src/hooks/use-post-meta/index.js
@@ -34,27 +34,30 @@ const usePostMeta = (postType = null, postId = null) => {
   const [metaRaw, setMetaRaw] = useEntityProp('postType', type, 'meta', id);
 
   /*
-   * Ensure set meta is a function. useEntityProp can return `undefined` if the post type doesn't
-   * have support for custom-fields.
+   * Ensure meta is an object and set meta is a function. useEntityProp can
+   * return `undefined` if the post type doesn't have support for custom-fields.
    */
+  const meta = typeof metaRaw === 'object' ? metaRaw : {};
   const setMeta = typeof setMetaRaw === 'function'
     ? setMetaRaw
     : () => console.error(`Error attempting to set post meta for post type ${type}. Does it have support for custom-fields?`); // eslint-disable-line no-console
 
   /**
-   * Wrapper for the setMeta function that updates the ref as well as the entity prop.
+   * Wrapper for the setMeta function that can accept a function as a setter which will get the
+   * latest edited meta from the data store.
    *
-   * @param {object} next - The new value for meta.
+   * @param {object|function} next - A new value for meta or a function that takes the current value
+   *                                 and returns a new value.
    */
   const setMetaSafe = (next) => {
     if (typeof next === 'object') {
       setMeta({ ...next });
     } else if (typeof next === 'function') {
-      setMeta(next(getLatestMeta()));
+      setMeta({ ...next(getLatestMeta()) });
     }
   };
 
-  return [metaRaw, setMetaSafe];
+  return [meta, setMetaSafe];
 };
 
 export default usePostMeta;


### PR DESCRIPTION
Allows `usePostMeta` and `usePostMetaValue` setter functions to accept a callable, which would accept the current meta value(s) and return updated values, similarly to how `useState()` works.

Resolves #674.