### PR TITLE
Issue-675: Block Editor Tools: Add A List View Option to PostPicker

### DIFF
--- a/.changeset/strange-oranges-relate.md
+++ b/.changeset/strange-oranges-relate.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/block-editor-tools": minor
+---
+
+Add list view option to PostPicker component

--- a/packages/block-editor-tools/src/components/post-picker/index.tsx
+++ b/packages/block-editor-tools/src/components/post-picker/index.tsx
@@ -24,6 +24,7 @@ interface PostPickerProps {
   className?: string;
   getPostType?: (id: number) => string;
   modalTitle?: string;
+  modalFormat?: 'grid' | 'list';
   onReset: () => void;
   onUpdate: (id: number) => void;
   params?: object;
@@ -51,9 +52,8 @@ const Preview = styled.div`
   border: 1px solid #eee;
   display: flex;
   flex-direction: column;
-  margin: 5px 0;
-  padding: 0.5rem 0.75rem;
-  text-align: center;
+  margin: 0 0 0.75rem;
+  padding: 0.75rem;
 `;
 
 const PostPicker = ({
@@ -61,6 +61,7 @@ const PostPicker = ({
   className,
   getPostType,
   modalTitle = __('Select Post', 'alley-scripts'),
+  modalFormat = 'grid',
   onReset,
   onUpdate,
   params = {},
@@ -112,7 +113,7 @@ const PostPicker = ({
         variant="secondary"
         onClick={onReset}
         style={{
-          margin: '0 4px',
+          margin: '0 0.5rem 0 0',
         }}
       >
         {resetText}
@@ -120,9 +121,6 @@ const PostPicker = ({
       <Button
         variant="secondary"
         onClick={openModal}
-        style={{
-          margin: '0 4px',
-        }}
       >
         {replaceText}
       </Button>
@@ -132,7 +130,7 @@ const PostPicker = ({
   // getEntityRecord returns `null` if the load is in progress.
   if (value !== 0 && post === null) {
     return (
-      <Spinner />
+      <Spinner onPointerEnterCapture={undefined} onPointerLeaveCapture={undefined} />
     );
   }
 
@@ -162,7 +160,7 @@ const PostPicker = ({
           {previewRender !== undefined ? (
             previewRender(post)
           ) : (
-            <Preview>
+            <Preview className="alley-scripts-post-picker__preview">
               <Post
                 title={title}
                 postType={type}
@@ -185,6 +183,7 @@ const PostPicker = ({
         <SearchModal
           closeModal={closeModal}
           baseUrl={baseUrl}
+          format={modalFormat}
           modalTitle={modalTitle}
           onUpdate={onUpdate}
           searchRender={searchRender}

--- a/packages/block-editor-tools/src/components/post-picker/post-list.scss
+++ b/packages/block-editor-tools/src/components/post-picker/post-list.scss
@@ -1,33 +1,166 @@
+.alley-scripts-post-picker__container {
+  height: calc(90vh - 220px);
+  // Allow space for focus state.
+  margin: 0 -0.5rem;
+  overflow-y: auto;
+  padding: 0 0.5rem;
+
+  @media (min-width: 600px) {
+    height: calc(70vh - 230px);
+  }
+}
+
 .alley-scripts-post-picker__post-list {
   display: flex;
   flex-wrap: wrap;
-  float: left;
-  height: calc(70vh - 200px);
   justify-content: flex-start;
-  overflow-y: auto;
-  padding: 8px;
+  padding-bottom: 2rem;
+  gap: 0.5rem;
   width: 100%;
-}
 
-.alley-scripts-post-picker__post {
-  border: 1px solid #eee;
-  height: auto;
-  justify-content: center;
-  margin: 0 8px 8px 0;
-  transition: background-color 0.2s ease-in-out;
-  width: calc((100% - 40px) / 3);
+  ul {
+    display: grid;
+    grid-gap: 0.5rem;
+    list-style: none;
+    margin: 0.5rem 0;
+    padding: 0;
+    width: 100%;
 
-
-  @media (min-width: 780px) {
-    width: calc((100% - 40px) / 5);
+    li {
+      margin: 0;
+      padding: 0;
+    }
   }
 
-  &:hover {
+  &.is-format-grid {
+    ul {
+      grid-template-columns: repeat(2, 1fr);
+
+      @media (min-width: 600px) {
+        grid-template-columns: repeat(3, 1fr);
+      }
+
+      @media (min-width: 1024px) {
+        grid-template-columns: repeat(5, 1fr);
+      }
+    }
+  }
+
+  .post-picker-spinner {
+    width: 100%;
+    display: flex;
+    height: 2.25rem;
+    justify-content: center;
+    padding: 0.5rem 0 0;
+  }
+}
+
+.alley-scripts-post-picker__post,
+.alley-scripts-post-picker__preview {
+  align-items: flex-start;
+  border: 1px solid #eee;
+  color: inherit;
+  height: 100%;
+  padding: 0.8rem;
+  text-align: left;
+  transition: background-color 0.2s ease-in-out;
+  width: 100%;
+
+  &.components-button:hover {
     background-color: #f0f0f0;
+    color: inherit;
   }
 
   &.is-selected {
     background-color: #f0f0f0;
+  }
+
+  .post-item {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+  }
+
+  .post-picker-result-title {
+    font-size: 1rem;
+    font-weight: 500;
+    margin: 0 0 0.3rem;
+    text-transform: none;
+    word-break: break-word;
+  }
+
+  .post-picker-result-image {
+    align-items: center;
+    aspect-ratio: 1 / 1;
+    background-color: #d6d6d6;
+    border-radius: 0.125rem;
+    display: flex;
+    height: 4.6875rem;
+    justify-content: center;
+    margin-bottom: 0.8rem;
+    width: 4.6875rem;
+
+    img {
+      aspect-ratio: 1 / 1;
+      border-radius: 0.125rem;
+      height: 4.6875rem;
+      width: 4.6875rem;
+    }
+  }
+
+  .result-image-fallback {
+    svg {
+      fill: #bdbdbd;
+      height: 3rem;
+      width: 3rem;
+    }
+  }
+
+  .post-picker-result-type {
+    color: inherit;
+    font-weight: 500;
+    margin: 0;
+    text-transform: capitalize;
+  }
+
+  .is-format-list & {
+    display: flex;
+    justify-content: flex-start;
+    width: 100%;
+
+    .post-item {
+      align-items: center;
+      column-gap: 1rem;
+      flex-direction: row;
+      width: 100%;
+
+      .post-picker-result-title {
+        margin-bottom: 0;
+      }
+
+      .post-picker-result-image {
+        height: 2rem;
+        margin: 0;
+        width: 2rem;
+
+        img {
+          height: 2rem;
+          width: 2rem;
+        }
+      }
+
+      .result-image-fallback {
+        svg {
+          height: 1.4rem;
+          width: 1.4rem;
+        }
+      }
+
+      .post-picker-result-type {
+        margin-left: auto;
+      }
+    }
   }
 }
 

--- a/packages/block-editor-tools/src/components/post-picker/post-list.tsx
+++ b/packages/block-editor-tools/src/components/post-picker/post-list.tsx
@@ -14,6 +14,7 @@ import Post from './post';
 
 interface PostListProps {
   baseUrl: string;
+  format?: 'grid' | 'list';
   searchRender?: (post: object) => JSX.Element;
   selected?: number;
   setSelected: (id: number) => void;
@@ -32,6 +33,7 @@ interface Params {
  */
 const PostList = ({
   baseUrl,
+  format,
   searchRender,
   selected,
   setSelected,
@@ -149,52 +151,71 @@ const PostList = ({
     };
   }, [getPosts, initialLoad, pathParams]);
 
+  const postListClasses = classNames(
+    'alley-scripts-post-picker__post-list',
+    format === 'list' ? 'is-format-list' : 'is-format-grid',
+  );
+
   return (
     <>
       <TextControl
+        className="post-list-search"
         value={pathParams.searchValue}
         placeholder={__('Search...', 'alley-scripts')}
         label={__('Search', 'alley-scripts')}
         // @ts-ignore
         onChange={handleSearchTextChange}
       />
-      <div className="alley-scripts-post-picker__post-list">
-        {listposts ? (
-          listposts.map((t) => (
-            <Button
-              key={t.id}
-              className={classNames({
-                'alley-scripts-post-picker__post': true,
-                'is-selected': t.id === selected,
-              })}
-              onClick={() => setSelected(t.id as number)}
-            >
-              {searchRender ? (
-                searchRender(t)
-              ) : (
-                <Post
-                  title={t.title}
-                  postType={t.subtype}
-                    // eslint-disable-next-line no-underscore-dangle
-                  attachmentID={t?._embedded?.self[0]?.featured_media}
-                />
-              )}
-            </Button>
-          ))
-        ) : null}
-        {isUpdating ? (
-          <Spinner />
-        ) : null}
-        {totalPages > 0 && pathParams.page < totalPages ? (
-          <div className="alley-scripts-post-picker__load-more">
-            <Button
-              variant="secondary"
-              onClick={loadMore}
-            >
-              {__('Load More', 'alley-scripts')}
-            </Button>
-          </div>
-        ) : null}
+      <div className="alley-scripts-post-picker__container">
+        <div className={postListClasses}>
+          <h2 id="post-picker-results-heading" className="screen-reader-text">
+            {__('Search Results', 'alley-scripts')}
+          </h2>
+          {listposts ? (
+            // eslint-disable-next-line jsx-a11y/no-redundant-roles
+            <ul aria-labelledby="post-picker-results-heading" role="list">
+              {listposts.map((t) => (
+                <li>
+                  <Button
+                    key={t.id}
+                    className={classNames({
+                      'alley-scripts-post-picker__post': true,
+                      'is-selected': t.id === selected,
+                    })}
+                    onClick={() => setSelected(t.id as number)}
+                  >
+                    {searchRender ? (
+                      searchRender(t)
+                    ) : (
+                      <Post
+                        format={format}
+                        title={t.title}
+                        postType={t.subtype}
+                          // eslint-disable-next-line no-underscore-dangle
+                        attachmentID={t?._embedded?.self[0]?.featured_media}
+                      />
+                    )}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {isUpdating ? (
+            <div className="post-picker-spinner">
+              <Spinner onPointerEnterCapture={undefined} onPointerLeaveCapture={undefined} />
+            </div>
+          ) : null}
+          {totalPages > 0 && pathParams.page < totalPages && !isUpdating ? (
+            <div className="alley-scripts-post-picker__load-more">
+              <Button
+                variant="secondary"
+                onClick={loadMore}
+              >
+                {__('Load More', 'alley-scripts')}
+              </Button>
+            </div>
+          ) : null}
+        </div>
       </div>
     </>
   );

--- a/packages/block-editor-tools/src/components/post-picker/post-list.tsx
+++ b/packages/block-editor-tools/src/components/post-picker/post-list.tsx
@@ -175,9 +175,8 @@ const PostList = ({
             // eslint-disable-next-line jsx-a11y/no-redundant-roles
             <ul aria-labelledby="post-picker-results-heading" role="list">
               {listposts.map((t) => (
-                <li>
+                <li key={t.id}>
                   <Button
-                    key={t.id}
                     className={classNames({
                       'alley-scripts-post-picker__post': true,
                       'is-selected': t.id === selected,

--- a/packages/block-editor-tools/src/components/post-picker/post.tsx
+++ b/packages/block-editor-tools/src/components/post-picker/post.tsx
@@ -1,12 +1,13 @@
+import classNames from 'classnames';
 import { decodeEntities } from '@wordpress/html-entities';
-import { sprintf } from '@wordpress/i18n';
 // eslint-disable-next-line camelcase
 import type { WP_REST_API_Attachment } from 'wp-types';
-import styled from 'styled-components';
+import { image } from '@wordpress/icons';
 import { useMedia } from '../../hooks';
 import SafeHTML from '../safe-html';
 
 interface PostInterface {
+  format?: 'grid' | 'list';
   title: string;
   postType: string,
   attachmentID: string | unknown,
@@ -23,23 +24,13 @@ interface Media extends WP_REST_API_Attachment {
   };
 }
 
-// Styled components.
-const PostDiv = styled.div`
-  align-items: center;
-  gap: 4px;
-  overflow-wrap: anywhere;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: 0.5rem 0.75rem;
-`;
-
 /**
  * Displays a single post.
  *
  * @param {obj} atts The attributes of the Post.
  */
 const Post = ({
+  format,
   title,
   postType,
   attachmentID,
@@ -48,26 +39,34 @@ const Post = ({
   const thumbUrl = media?.media_details?.sizes?.thumbnail?.source_url;
   const thumbAlt = media?.alt_text ?? '';
 
+  const postClasses = classNames(
+    'post-item',
+    format === 'list' ? 'is-format-list' : '',
+  );
+
   return (
-    <PostDiv>
-      {thumbUrl ? (
-        <img
-          style={{ maxWidth: '100%', height: 'auto' }}
-          loading="lazy"
-          src={thumbUrl}
-          alt={thumbAlt}
-        />
-      ) : null}
+    <div className={postClasses}>
+      <div className="post-picker-result-image">
+        {thumbUrl ? (
+          <img
+            style={{ maxWidth: '100%', height: 'auto' }}
+            loading="lazy"
+            src={thumbUrl}
+            alt={thumbAlt}
+          />
+        ) : (
+          <div className="result-image-fallback">
+            {image}
+          </div>
+        )}
+      </div>
       <SafeHTML
         html={decodeEntities(title)}
         className="post-picker-result-title"
-        tag="strong"
+        tag="h3"
       />
-      {sprintf(
-        ' (%s)',
-        postType,
-      )}
-    </PostDiv>
+      <p className="post-picker-result-type">{postType}</p>
+    </div>
   );
 };
 

--- a/packages/block-editor-tools/src/components/post-picker/search-modal.scss
+++ b/packages/block-editor-tools/src/components/post-picker/search-modal.scss
@@ -1,16 +1,27 @@
 .alley-scripts-post-picker__modal {
   .components-modal__content {
-    width: 90vw;
+    width: 85vw;
+  }
+
+  .post-list-search {
+    margin: 0 0 1rem;
+  }
+
+  &.is-format-list {
+    .components-modal__content {
+      max-width: 37.5rem;
+    }
   }
 }
 
 .alley-scripts-post-picker__buttons {
   clear: both;
   display: block;
+  padding-top: 0.75rem;
   text-align: right;
   width: 100%;
 
   button {
-    margin: 5px;
+    margin: 0 0 0 0.5rem;
   }
 }

--- a/packages/block-editor-tools/src/components/post-picker/search-modal.tsx
+++ b/packages/block-editor-tools/src/components/post-picker/search-modal.tsx
@@ -1,4 +1,5 @@
 import { useState, JSX } from 'react';
+import classNames from 'classnames';
 import {
   Button,
   Modal,
@@ -12,6 +13,7 @@ import PostList from './post-list';
 interface SearchModalProps {
   baseUrl: string;
   closeModal: () => void;
+  format?: 'grid' | 'list';
   modalTitle: string;
   onUpdate: (id: number) => void;
   searchRender?: (post: object) => JSX.Element;
@@ -21,6 +23,7 @@ interface SearchModalProps {
 const SearchModal = ({
   baseUrl,
   closeModal,
+  format = 'grid',
   modalTitle,
   onUpdate,
   searchRender,
@@ -36,9 +39,14 @@ const SearchModal = ({
     closeModal();
   };
 
+  const modalClasses = classNames(
+    'alley-scripts-post-picker__modal',
+    format === 'list' ? 'is-format-list' : 'is-format-grid',
+  );
+
   return (
     <Modal
-      className="alley-scripts-post-picker__modal"
+      className={modalClasses}
       isDismissible
       title={modalTitle}
       onRequestClose={closeModal}
@@ -46,6 +54,7 @@ const SearchModal = ({
     >
       <PostList
         baseUrl={baseUrl}
+        format={format}
         selected={selected ?? 0}
         setSelected={setSelected}
         searchRender={searchRender}

--- a/plugin/entries/slotfills/index.php
+++ b/plugin/entries/slotfills/index.php
@@ -54,4 +54,5 @@ add_action( 'init', __NAMESPACE__ . '\register_example_slotfills_scripts' );
  */
 function action_enqueue_example_slotfills_assets() {
 	wp_enqueue_script( 'alley-scripts-demo-plugin-example_slotfills' );
+	wp_enqueue_style( 'alley-scripts-demo-plugin-example_slotfills', plugins_url( 'index.css', __FILE__ ), [], '1.0.0' );
 }

--- a/plugin/entries/slotfills/index.tsx
+++ b/plugin/entries/slotfills/index.tsx
@@ -46,6 +46,7 @@ registerPlugin('alley-scripts-plugin-sidebar', {
       alley_scripts_image_picker_id: imageId = '',
       alley_scripts_media_picker_id: mediaId = 0,
       alley_scripts_post_picker_id: postId = 0,
+      alley_scripts_post_picker_list_id: listPostId = 0,
       alley_scripts_repeater: repeater = [],
     } = meta;
 
@@ -99,11 +100,19 @@ registerPlugin('alley-scripts-plugin-sidebar', {
               onSelect={(value: any) => console.log('PostSelector onSelect', value)} // eslint-disable-line no-console
             />
           </PanelBody>
-          <PanelBody initialOpen title={__('Post Picker', 'alley-scripts')}>
+          <PanelBody initialOpen title={__('Post Picker (Grid)', 'alley-scripts')}>
             <PostPicker
               onUpdate={(id: number) => setMeta({ alley_scripts_post_picker_id: id })}
               onReset={() => setMeta({ alley_scripts_post_picker_id: 0 })}
               value={postId}
+            />
+          </PanelBody>
+          <PanelBody initialOpen title={__('Post Picker (List)', 'alley-scripts')}>
+            <PostPicker
+              modalFormat='list'
+              onUpdate={(id: number) => setMeta({ alley_scripts_post_picker_list_id: id })}
+              onReset={() => setMeta({ alley_scripts_post_picker_list_id: 0 })}
+              value={listPostId}
             />
           </PanelBody>
           <PanelBody initialOpen title={__('Term Selector', 'alley-scripts')}>

--- a/plugin/entries/slotfills/index.tsx
+++ b/plugin/entries/slotfills/index.tsx
@@ -109,7 +109,7 @@ registerPlugin('alley-scripts-plugin-sidebar', {
           </PanelBody>
           <PanelBody initialOpen title={__('Post Picker (List)', 'alley-scripts')}>
             <PostPicker
-              modalFormat='list'
+              modalFormat="list"
               onUpdate={(id: number) => setMeta({ alley_scripts_post_picker_list_id: id })}
               onReset={() => setMeta({ alley_scripts_post_picker_list_id: 0 })}
               value={listPostId}

--- a/plugin/plugin.php
+++ b/plugin/plugin.php
@@ -72,6 +72,15 @@ function main() {
 	register_meta_helper(
 		'post',
 		[ 'post' ],
+		'alley_scripts_post_picker_list_id',
+		[
+			'type' => 'integer',
+		]
+	);
+
+	register_meta_helper(
+		'post',
+		[ 'post' ],
 		'alley_scripts_repeater',
 		[
 			'type'         => 'array',


### PR DESCRIPTION
### Summary

Fixes #675

### Description

This PR introduces an option to the PostPicker component to display using a "list" view type. This option allows for a more compact selection experience, with the grid view remaining as the default. Implementers can now choose to use the list view if they prefer.

### Use Case

This enhancement is particularly useful for users seeking a more compact post selection interface. By opting for the list view, the selection process becomes streamlined and potentially more user-friendly, depending on the specific implementation context.

### Test Instructions

1. Integrate the updated PostPicker into your project.
2. Verify that the PostPicker defaults to the modal view.
3. Opt-in to the `list` view by using the new `modalFormat` prop on the `PostPicker` component.
4. Test the list view to ensure it presents a compact and functional interface for post selection.
