### PR TITLE
Issue-665: Add dist folder to exclude config

### DIFF
--- a/.changeset/serious-nails-visit.md
+++ b/.changeset/serious-nails-visit.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/tsconfig": minor
+---
+
+Add dist folder to excludes list

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -26,6 +26,7 @@
   },
   "exclude": [
     "build",
+    "dist",
     "jest.config.js",
     "node_modules",
     "tests",


### PR DESCRIPTION
### Summary

Add `dist/` folder to the base tsconfig file `excludes` setting.

### Changes

- Add `dist/` folder to the base tsconfig file `excludes` setting.

### Testing

- Ensure that removing the default values does not affect the build and run-time behavior of projects using this configuration.
- Verify that the upgrade to the shared standard configuration is seamlessly integrated.
