### PR TITLE
Issue-698: Webpack Config Types for ESM

### DIFF
--- a/.changeset/tiny-coins-return.md
+++ b/.changeset/tiny-coins-return.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/build-tool": patch
+---
+
+Fix ESM import types for Webpack configs.

--- a/packages/build-tool/package.json
+++ b/packages/build-tool/package.json
@@ -68,7 +68,13 @@
         "default": "./dist/cjs/index.js"
       }
     },
-    "./dist/cjs/config/webpack.config": "./dist/cjs/config/webpack.config.js",
-    "./dist/esm/config/webpack.config": "./dist/esm/config/webpack.config.js"
+    "./dist/cjs/config/webpack.config": {
+      "types": "./dist/cjs/types/config/webpack.config.d.ts",
+      "default": "./dist/cjs/config/webpack.config.js"
+    },
+    "./dist/esm/config/webpack.config": {
+      "types": "./dist/esm/types/config/webpack.config.d.ts",
+      "default": "./dist/esm/config/webpack.config.js"
+    }
   }
 }


### PR DESCRIPTION
### Summary

Fixes #698

This pull request addresses the issue where importing the default Webpack config into an ESM project results in a build error due to missing type declarations. The changes ensure compatibility with ESM projects by providing the necessary type definitions and updating the package exports structure.

### Changes

- Added type declarations for the Webpack config to support ESM projects.
- Updated the `exports` field in the `package.json` file for the `@alleyinteractive/build-tool` package to include:
  - `types` fields pointing to the TypeScript declaration files for both CommonJS and ESM configurations.
  - `default` fields pointing to the JavaScript implementation files.
- Revised the import/export structure to align with ESM standards.

### Testing Instructions

1. Create a new ESM-based project.
2. Import the default Webpack config:
   ```javascript
   import defaultConfig from '@alleyinteractive/build-tool/dist/esm/config/webpack.config';
   ```
3. Build the project and confirm that no errors occur.

### Additional Notes

- This change does not affect CommonJS users.
- Please ensure that all existing tests pass and new tests are added if necessary.