### PR TITLE
Issue-809: Display Selector options under the empty field

### DIFF
--- a/.changeset/perfect-ways-bow.md
+++ b/.changeset/perfect-ways-bow.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/block-editor-tools": minor
+---
+
+Update TermSelector component to use FormTokenField

--- a/packages/block-editor-tools/README.md
+++ b/packages/block-editor-tools/README.md
@@ -326,12 +326,39 @@ Importantly, this component does not save the selected item, it just returns it 
 | threshold   | 3                | false    | integer  | If specified, this overrides the default minimum number of characters that must be entered in order for the search to fire. |
 
 
-### TermSelect
+### TermSelector
 
-A component for selecting terms.
+Allows users to select an term or multiple terms using a search query against the REST API. Optionally, accepts a list of subtypes to which to restrict the search. Utilizes the search endpoint, so terms must have the appropriate visibility within the REST API to appear in the result list.
+
+Importantly, this component does not save the selected term, it just returns it in the `onSelect` method. The enclosing block or component is responsible for managing the selected terms in some way, and using this component as a method for picking a new one.
 
 **Usage**
-See the Selector component for usage details. The `type` prop is preset to `term`.
+
+``` js
+  <TermSelector
+    className="custom-termselector-classname"
+    label="Select a category"
+    multiple
+    onSelect={onSelect}
+    placeholder="Select a category..."
+    subTypes={['category', 'post_tag']}
+    selected={[{
+      id: 123,
+      title: 'Title of Category',
+    }]}
+  />
+```
+**Props**
+
+| Prop        | Default          | Required | Type     | Description                                                                                                                 |
+|-------------|------------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| className   |                  | false    | string   | If specified, the className is prepended to the top-level container.                                                        |
+| label       | Search for items | false    | string   | If specified, this overrides the default label text for the item selection search input.                                    |
+| multiple    | false            | false    | boolean  | If set to true the component allows for the ability to select multiple terms returned through the `onSelect` callback.      |
+| onSelect    | NA               | true     | function | Callback to receive the selected item array, as it is returned from the `search` REST endpoint. Required.                   |
+| placeholder | Search for items | false    | string   | If specified, this overrides the default input placeholder value.                                                           |
+| subTypes   | []               | false    | array    | All queryable subtypes that will be included in the form of a comma-separated array. The default query is "any" subtype.     |
+| selected    | []               | false    | array    | Optional array of objects with id and title keys to auto-hydrate selections on load.                                        |
 
 ### VideoPicker
 

--- a/packages/block-editor-tools/src/components/term-selector/index.tsx
+++ b/packages/block-editor-tools/src/components/term-selector/index.tsx
@@ -109,6 +109,7 @@ const TermSelector = <T extends Record<string, unknown>>({
   }, [fetchItems]);
 
   const onChange = (tokens: string[]) => {
+    if (!multiple && tokens.length > 1) return;
     const tokensWithIds = tokens.map((token) => ({
       id: foundItems.find((item) => item.title === token)?.id ?? 0,
       title: token,
@@ -132,7 +133,7 @@ const TermSelector = <T extends Record<string, unknown>>({
       placeholder={placeholder}
       suggestions={foundItems.map((item) => item.title)}
       value={selectedItems}
-      maxLength={multiple ? 1 : undefined}
+      maxLength={multiple ? undefined : 1}
       maxSuggestions={999}
     />
   );

--- a/packages/block-editor-tools/src/components/term-selector/index.tsx
+++ b/packages/block-editor-tools/src/components/term-selector/index.tsx
@@ -1,6 +1,14 @@
 // Dependencies.
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { FormTokenField } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
-import { Selector } from '..';
 
 type BaseSelectedTerm = {
   id: number;
@@ -11,7 +19,6 @@ type SelectedTerm<T extends Record<string, unknown> = {}> = BaseSelectedTerm & T
 
 type TermSelectorProps<T extends Record<string, unknown> = {}> = {
   className?: string;
-  emptyLabel?: string;
   label?: string;
   maxPages?: number;
   multiple?: boolean;
@@ -19,34 +26,116 @@ type TermSelectorProps<T extends Record<string, unknown> = {}> = {
   placeholder?: string;
   selected?: SelectedTerm<T>[];
   subTypes?: string[];
-  threshold?: number;
 };
 
 const TermSelector = <T extends Record<string, unknown>>({
   className = '',
-  emptyLabel = __('No terms found', 'alley-scripts'),
   label = __('Search for terms', 'alley-scripts'),
   maxPages = 5,
   multiple = false,
   onSelect,
-  placeholder = __('Search for terms', 'alley-scripts'),
+  placeholder,
   selected = [],
   subTypes = [],
-  threshold = 3,
-}: TermSelectorProps<T>) => (
-  <Selector
-    className={className}
-    emptyLabel={emptyLabel}
-    label={label}
-    maxPages={maxPages}
-    multiple={multiple}
-    onSelect={onSelect}
-    placeholder={placeholder}
-    selected={selected}
-    subTypes={subTypes}
-    threshold={threshold}
-    type="term"
-  />
+}: TermSelectorProps<T>) => {
+  // Create array of titles from selected value.
+  const selectedTitles = Array.from(selected.map((item) => item.title));
+
+  // Setup state.
+  const [foundItems, setFoundItems] = useState<BaseSelectedTerm[]>([]);
+  const [selectedItems, setSelectedItems] = useState(selectedTitles);
+
+  // Memoize subType string.
+  const selectedSubTypes = useMemo(() => (subTypes.length > 0 ? subTypes.join(',') : 'any'), [subTypes]);
+
+  /**
+   * Make API request for items by search string.
+   *
+   * @param {int} page current page number.
+   */
+  const fetchItems = useCallback(async (page = 1) => {
+    // Page count.
+    let totalPages = 0;
+
+    if (page === 1) {
+      // Reset state before we start the fetch.
+      setFoundItems([]);
+    }
+
+    // Get search results from the API and store them.
+    const path = addQueryArgs(
+      '/wp/v2/search',
+      {
+        page,
+        per_page: 100,
+        subtype: selectedSubTypes,
+        type: 'term',
+      },
+    );
+
+    // Fetch items by page.
+    await apiFetch({ path, parse: false })
+      .then((response) => {
+        const totalPagesFromResponse = parseInt(
+          // @ts-ignore
+          response.headers.get('X-WP-TotalPages'),
+          10,
+        );
+        // Set totalPage count to received page count unless larger than maxPages prop.
+        totalPages = totalPagesFromResponse > maxPages
+          ? maxPages : totalPagesFromResponse;
+        // @ts-ignore
+        return response.json();
+      })
+      .then((items) => {
+        // @ts-ignore
+        setFoundItems((prevState) => [...prevState, ...items]);
+
+        // Continue to fetch additional page results.
+        if (
+          (totalPages && totalPages > page)
+        ) {
+          fetchItems(page + 1);
+        }
+      })
+      .catch((err) => console.error(err.message)); // eslint-disable-line no-console
+  }, [maxPages, selectedSubTypes]);
+
+  /**
+   * Kick off initial fetch.
+   */
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  const onChange = (tokens: string[]) => {
+    const tokensWithIds = tokens.map((token) => ({
+      id: foundItems.find((item) => item.title === token)?.id ?? 0,
+      title: token,
+    }));
+    setSelectedItems(tokens);
+    // @ts-ignore
+    onSelect(tokensWithIds);
+  };
+  const tokenIsValid = (title: string) => foundItems.some((item) => item.title === title);
+
+  return (
+    <FormTokenField
+      className={className}
+      __experimentalExpandOnFocus
+      __experimentalValidateInput={tokenIsValid}
+      __next40pxDefaultSize
+      __nextHasNoMarginBottom
+      label={label}
+      // @ts-ignore
+      onChange={onChange}
+      placeholder={placeholder}
+      suggestions={foundItems.map((item) => item.title)}
+      value={selectedItems}
+      maxLength={multiple ? 1 : undefined}
+      maxSuggestions={999}
+    />
   );
+};
 
 export default TermSelector;


### PR DESCRIPTION
## Summary

This updates the `TermSelector` component to use the `FormTokenField` component from `@wordpress/components` to display term suggestions and currently selected terms.

This retains the `Selector` component in its current state and detaches the `TermSelector` from it. It's only being used by the deprecated `PostSelector`, so could be deprecated after this change is merged.

Addresses #809 