### PR TITLE
Issue-762: Build plugin alongside packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build-storybook": "storybook build"
   },
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "plugin"
   ],
   "devDependencies": {
     "@babel/core": "^7.23.3",


### PR DESCRIPTION
## Summary

This tells Turbo to include the sample plugin alongside any changes to packages.

This is a follow up to #812.