### PR TITLE
Issue-899: Unknown option `textdomain` when using create-block script

### DIFF
--- a/.changeset/little-pillows-behave.md
+++ b/.changeset/little-pillows-behave.md
@@ -1,5 +1,5 @@
 ---
-"@alleyinteractive/create-block": minor
+"@alleyinteractive/create-block": patch
 ---
 
-Fixes an issue where the create-block command was failing due to an `unknown option '--textdomain'` issue, caused by the option not being available in versions of `@wordpress/create-block` prior to `4.66.0`
+Fixes an issue where the create-block command was failing due to an `unknown option '--textdomain'` error, caused by the option not being available in versions of `@wordpress/create-block` prior to `4.66.0`. Tightens the `@wordpress/create-block` version constraint from `*` to `^4.66.0` in both `dependencies` and `peerDependencies`.

--- a/.changeset/little-pillows-behave.md
+++ b/.changeset/little-pillows-behave.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/create-block": minor
+---
+
+Fixes an issue where the create-block command was failing due to an `unknown option '--textdomain'` issue, caused by the option not being available in versions of `@wordpress/create-block` prior to `4.66.0`

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -19,7 +19,7 @@
     "alley-create-block": "./dist/index.js"
   },
   "peerDependencies": {
-    "@wordpress/create-block": "*",
+    "@wordpress/create-block": "^4.66.0",
     "@wordpress/scripts": "*"
   },
   "keywords": [
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/alleyinteractive/alley-scripts/tree/main/packages/create-block",
   "dependencies": {
-    "@wordpress/create-block": "*",
+    "@wordpress/create-block": "^4.66.0",
     "chalk": "^4.1.2",
     "command-line-args": "^5.2.1",
     "command-line-usage": "^7.0.1",


### PR DESCRIPTION
### Summary

Fixes #899

### What does this PR do?

This pull request addresses the issue where running `npx @alleyinteractive/create-block@latest` results in an error after the `Will this block have a front end view script?` prompt due to an unknown option `--textdomain`.

### How to test

1. Run `npx @alleyinteractive/create-block@latest`.
2. Ensure the script proceeds past the `Will this block have a front end view script?` prompt without encountering the error: `error: unknown option '--textdomain'`.

### Additional context

See issue: https://github.com/alleyinteractive/alley-scripts/issues/899
