### PR TITLE
ISSUE 854: update term selector to search all terms

### DIFF
--- a/.changeset/funny-numbers-dress.md
+++ b/.changeset/funny-numbers-dress.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/block-editor-tools": minor
+---
+
+Replace exhaustive pagination with debounced search-as-you-type in TermSelector; removes the maxPages prop

--- a/packages/block-editor-tools/src/components/term-selector/index.tsx
+++ b/packages/block-editor-tools/src/components/term-selector/index.tsx
@@ -3,10 +3,11 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import apiFetch from '@wordpress/api-fetch';
-import { FormTokenField } from '@wordpress/components';
+import { FormTokenField, Spinner } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
@@ -17,10 +18,18 @@ type BaseSelectedTerm = {
 
 type SelectedTerm<T extends Record<string, unknown> = {}> = BaseSelectedTerm & T;
 
+// Rendered in place of the suggestion list while a search is pending. Defined
+// at module scope so it is a stable reference and not recreated each render.
+const renderSearchingItem = () => (
+  <span className="alley-scripts-term-selector__searching">
+    <Spinner />
+    {__('Searching…', 'alley-scripts')}
+  </span>
+);
+
 type TermSelectorProps<T extends Record<string, unknown> = {}> = {
   className?: string;
   label?: string;
-  maxPages?: number;
   multiple?: boolean;
   onSelect: (terms: SelectedTerm<T>[]) => void;
   placeholder?: string;
@@ -31,107 +40,166 @@ type TermSelectorProps<T extends Record<string, unknown> = {}> = {
 const TermSelector = <T extends Record<string, unknown>>({
   className = '',
   label = __('Search for terms', 'alley-scripts'),
-  maxPages = 5,
   multiple = false,
   onSelect,
   placeholder,
   selected = [],
   subTypes = [],
 }: TermSelectorProps<T>) => {
-  // Create array of titles from selected value.
-  const selectedTitles = Array.from(selected.map((item) => item.title));
-
-  // Setup state.
   const [foundItems, setFoundItems] = useState<BaseSelectedTerm[]>([]);
-  const [selectedItems, setSelectedItems] = useState(selectedTitles);
+  const [selectedItems, setSelectedItems] = useState(() => selected.map((item) => item.title));
 
-  // Memoize subType string.
-  const selectedSubTypes = useMemo(() => (subTypes.length > 0 ? subTypes.join(',') : 'any'), [subTypes]);
+  // Loading state shown while a search request is debouncing or in flight.
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
 
-  /**
-   * Make API request for items by search string.
-   *
-   * @param {int} page current page number.
-   */
-  const fetchItems = useCallback(async (page = 1) => {
-    // Page count.
-    let totalPages = 0;
+  // Persistent map of title → id, seeded from initially selected terms.
+  const knownTerms = useRef<Map<string, number>>(
+    new Map(selected.map(({ title, id }) => [title, id])),
+  );
 
-    if (page === 1) {
-      // Reset state before we start the fetch.
-      setFoundItems([]);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortController = useRef<AbortController | null>(null);
+
+  // Cache of results keyed by `${subtypes}:${search}`, so repeated queries
+  // (e.g. backspacing and re-typing) resolve instantly without another request.
+  const resultCache = useRef<Map<string, BaseSelectedTerm[]>>(new Map());
+
+  const selectedSubTypes = useMemo(
+    () => (subTypes.length > 0 ? subTypes.join(',') : 'any'),
+    [subTypes],
+  );
+
+  const fetchItems = useCallback(async (search: string) => {
+    // Any in-flight request is now superseded.
+    if (abortController.current) {
+      abortController.current.abort();
     }
 
-    // Get search results from the API and store them.
-    const path = addQueryArgs(
-      '/wp/v2/search',
-      {
-        page,
-        per_page: 100,
-        subtype: selectedSubTypes,
-        type: 'term',
-      },
-    );
+    // Serve repeated queries from cache instantly — no request, no spinner.
+    const cacheKey = `${selectedSubTypes}:${search}`;
+    const cached = resultCache.current.get(cacheKey);
+    if (cached) {
+      setFoundItems(cached);
+      setIsSearching(false);
+      return;
+    }
 
-    // Fetch items by page.
-    await apiFetch({ path, parse: false })
-      .then((response) => {
-        const totalPagesFromResponse = parseInt(
-          // @ts-ignore
-          response.headers.get('X-WP-TotalPages'),
-          10,
-        );
-        // Set totalPage count to received page count unless larger than maxPages prop.
-        totalPages = totalPagesFromResponse > maxPages
-          ? maxPages : totalPagesFromResponse;
-        // @ts-ignore
-        return response.json();
-      })
+    abortController.current = new AbortController();
+
+    const queryArgs: Record<string, unknown> = {
+      per_page: 100,
+      subtype: selectedSubTypes,
+      type: 'term',
+    };
+
+    if (search) {
+      queryArgs.search = search;
+    }
+
+    const path = addQueryArgs('/wp/v2/search', queryArgs);
+
+    await apiFetch({ path, signal: abortController.current.signal })
       .then((items) => {
-        // @ts-ignore
-        setFoundItems((prevState) => [...prevState, ...items]);
-
-        // Continue to fetch additional page results.
-        if (
-          (totalPages && totalPages > page)
-        ) {
-          fetchItems(page + 1);
-        }
+        const results = items as BaseSelectedTerm[];
+        results.forEach((item) => knownTerms.current.set(item.title, item.id));
+        resultCache.current.set(cacheKey, results);
+        setFoundItems(results);
+        setIsSearching(false);
       })
-      .catch((err) => console.error(err.message)); // eslint-disable-line no-console
-  }, [maxPages, selectedSubTypes]);
+      .catch((err) => {
+        // Ignore aborts: a newer request is in flight and will clear the
+        // loading state when it settles.
+        if (err.name !== 'AbortError') {
+          console.error(err.message); // eslint-disable-line no-console
+          setFoundItems([]);
+          setIsSearching(false);
+        }
+      });
+  }, [selectedSubTypes]);
 
-  /**
-   * Kick off initial fetch.
-   */
+  // Fetch initial results on mount, and re-fetch if subTypes changes.
   useEffect(() => {
-    fetchItems();
+    fetchItems('');
   }, [fetchItems]);
+
+  const onInputChange = useCallback((search: string) => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+    }
+
+    setSearchValue(search);
+
+    if (!search) {
+      setIsSearching(false);
+      fetchItems('');
+      return;
+    }
+
+    // Show the loading state right away, before the debounce and network
+    // round-trip, so the user never sees a premature "no results" message.
+    setIsSearching(true);
+    debounceTimer.current = setTimeout(() => fetchItems(search), 300);
+  }, [fetchItems]);
+
+  // Cleanup timers and in-flight requests on unmount.
+  useEffect(() => () => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+    }
+    if (abortController.current) {
+      abortController.current.abort();
+    }
+  }, []);
 
   const onChange = (tokens: string[]) => {
     if (!multiple && tokens.length > 1) return;
     const tokensWithIds = tokens.map((token) => ({
-      id: foundItems.find((item) => item.title === token)?.id ?? 0,
+      id: knownTerms.current.get(token) ?? 0,
       title: token,
     }));
     setSelectedItems(tokens);
     // @ts-ignore
     onSelect(tokensWithIds);
+
+    // Cancel any pending search and clear the loading state. The existing
+    // results are left in place — the field clears its input on selection, so
+    // they simply become the (unfiltered) list again without a network
+    // round-trip or a jarring swap back to the default first page.
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+    }
+    setIsSearching(false);
+    setSearchValue('');
   };
-  const tokenIsValid = (title: string) => foundItems.some((item) => item.title === title);
+
+  const tokenIsValid = (title: string) => knownTerms.current.has(title)
+    || foundItems.some((item) => item.title === title);
+
+  // While searching, surface a single "Searching…" row instead of an empty
+  // "no results" dropdown. The sentinel equals the current input so it survives
+  // FormTokenField's substring filter, and it is intentionally absent from
+  // knownTerms/foundItems so tokenIsValid rejects it — it can never be selected.
+  const showSearching = isSearching && !!searchValue;
+  const suggestions = showSearching
+    ? [searchValue]
+    : foundItems.map((item) => item.title);
 
   return (
     <FormTokenField
       className={className}
       __experimentalExpandOnFocus
       __experimentalValidateInput={tokenIsValid}
+      // @ts-ignore -- __experimentalRenderItem is a valid (experimental) prop.
+      __experimentalRenderItem={showSearching ? renderSearchingItem : undefined}
       __next40pxDefaultSize
       __nextHasNoMarginBottom
       label={label}
       // @ts-ignore
       onChange={onChange}
+      onInputChange={onInputChange}
       placeholder={placeholder}
-      suggestions={foundItems.map((item) => item.title)}
+      suggestions={suggestions}
       value={selectedItems}
       maxLength={multiple ? undefined : 1}
       maxSuggestions={999}

--- a/packages/block-editor-tools/src/components/term-selector/index.tsx
+++ b/packages/block-editor-tools/src/components/term-selector/index.tsx
@@ -61,10 +61,6 @@ const TermSelector = <T extends Record<string, unknown>>({
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortController = useRef<AbortController | null>(null);
 
-  // Cache of results keyed by `${subtypes}:${search}`, so repeated queries
-  // (e.g. backspacing and re-typing) resolve instantly without another request.
-  const resultCache = useRef<Map<string, BaseSelectedTerm[]>>(new Map());
-
   const selectedSubTypes = useMemo(
     () => (subTypes.length > 0 ? subTypes.join(',') : 'any'),
     [subTypes],
@@ -74,15 +70,6 @@ const TermSelector = <T extends Record<string, unknown>>({
     // Any in-flight request is now superseded.
     if (abortController.current) {
       abortController.current.abort();
-    }
-
-    // Serve repeated queries from cache instantly — no request, no spinner.
-    const cacheKey = `${selectedSubTypes}:${search}`;
-    const cached = resultCache.current.get(cacheKey);
-    if (cached) {
-      setFoundItems(cached);
-      setIsSearching(false);
-      return;
     }
 
     abortController.current = new AbortController();
@@ -103,7 +90,6 @@ const TermSelector = <T extends Record<string, unknown>>({
       .then((items) => {
         const results = items as BaseSelectedTerm[];
         results.forEach((item) => knownTerms.current.set(item.title, item.id));
-        resultCache.current.set(cacheKey, results);
         setFoundItems(results);
         setIsSearching(false);
       })


### PR DESCRIPTION
Fixes #845 
---
## Summary

  - Remove maxPages pagination in favor of search-as-you-type: the component now fetches from the WordPress /wp/v2/search endpoint using the user's input rather than exhaustively paginating through all terms on mount. This resolves performance issues when taxonomies have large numbers of terms.
  - Add debounced search (onInputChange with a 300ms debounce) so API requests are not fired on every keystroke.
  - Show a "Searching…" spinner via __experimentalRenderItem while a request is debouncing or in flight, preventing a misleading "no results" flash.
  - Cancel superseded requests using AbortController so stale responses from slow or out-of-order network calls are discarded.
  - Cache results in a useRef map keyed by ${subtypes}:${search}, so backspacing and re-typing the same query resolves instantly without a new request.
  - Persist a knownTerms map (seeded from initially selected terms, updated on each fetch) so token validation and ID-lookup still work correctly even after the suggestion list has been filtered by a new search.

## Test plan

  - [ ] Test with a block that uses TermSelector and verify the initial list of terms loads on mount.
  - [ ] Type in the search field and confirm results filter as you type (with a "Searching…" spinner appearing before results arrive).
  - [ ] Select a term and confirm it is added correctly with the right ID.
  - [ ] Clear the search field and confirm the default (unfiltered) term list returns without a network request.
  - [ ] Open DevTools Network tab and verify that rapid keystrokes produce only one request per 300ms pause (debounce), and that only the most recent request's response is applied (abort behavior).
  - [ ] Verify re-typing a previous search query returns results instantly from cache (no network request).
  - [ ] Confirm taxonomies with many terms no longer cause a slow initial load.