### PR TITLE
pin release workflow to npm 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,10 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      # Ensure npm 11.5.1 or later is installed
+      # Ensure npm 11.5.1 or later is installed (pin to 11.x; npm 12 changed
+      # `npm info --json` output and breaks changeset publish's registry check)
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install Dependencies
         run: npm ci
@@ -72,9 +73,10 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      # Ensure npm 11.5.1 or later is installed
+      # Ensure npm 11.5.1 or later is installed (pin to 11.x; npm 12 changed
+      # `npm info --json` output and breaks changeset publish's registry check)
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
Pins npm to version 11 in the `Update NPM` command in the release workflow.

npm 12 changed the output shape of `npm info <pkg> --json`: it now returns an array wrapping the package object instead of the bare object. Changesets parses that JSON and reads .versions off the result to decide whether a package's local version is already on the registry. On an array, .versions is undefined, so changesets concludes every package "has not been published on npm."