### PR TITLE
Add starting-style to allowed list of at rules

### DIFF
--- a/.changeset/good-needles-float.md
+++ b/.changeset/good-needles-float.md
@@ -1,0 +1,5 @@
+---
+"@alleyinteractive/stylelint-config": minor
+---
+
+Add @starting-style to allowed at-rules

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -7,6 +7,12 @@ export default {
         ignoreAtRules: ["each", "media", "supports", "include"]
       }
     ],
+    "scss/at-rule-no-unknown": [
+      true,
+      {
+        ignoreAtRules: ["starting-style"]
+      }
+    ],
     "selector-class-pattern": [
       "^[a-z0-9\\-_]+$",
       {

--- a/plugin/composer.json
+++ b/plugin/composer.json
@@ -14,7 +14,7 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "alleyinteractive/alley-coding-standards": "^1.0"
+        "alleyinteractive/alley-coding-standards": "^2.5.0"
     },
     "config": {
         "sort-packages": true,

--- a/plugin/plugin.php
+++ b/plugin/plugin.php
@@ -132,7 +132,7 @@ main();
  * @param mixed $meta_value Meta value to sanitize.
  * @return string Sanitized meta value.
  */
-function sanitize_csv_data( $meta_value ) : string {
+function sanitize_csv_data( $meta_value ): string {
 	// The meta value should be a stringified JSON array. Ensure that it is.
 	$raw_meta_value = json_decode( $meta_value, true );
 	if ( ! is_array( $raw_meta_value ) ) {

--- a/plugin/src/assets.php
+++ b/plugin/src/assets.php
@@ -32,7 +32,7 @@ function action_enqueue_block_editor_assets() {
  * @param string $path The file path to validate.
  * @return bool        True if the path is valid and the file exists.
  */
-function validate_path( string $path ) : bool {
+function validate_path( string $path ): bool {
 	return ( 0 === validate_file( $path ) || 2 === validate_file( $path ) ) && file_exists( $path );
 }
 
@@ -88,7 +88,7 @@ function get_entry_asset_map( string $dir_entry_name ) {
  *
  * @return array The asset's dependency array.
  */
-function get_asset_dependency_array( string $dir_entry_name ) : array {
+function get_asset_dependency_array( string $dir_entry_name ): array {
 	$asset_arr = get_entry_asset_map( $dir_entry_name );
 	return $asset_arr['dependencies'] ?? [];
 }
@@ -100,7 +100,7 @@ function get_asset_dependency_array( string $dir_entry_name ) : array {
  *
  * @return string The asset's version hash.
  */
-function get_asset_version( string $dir_entry_name ) : string {
+function get_asset_version( string $dir_entry_name ): string {
 	$asset_arr = get_entry_asset_map( $dir_entry_name );
 	return $asset_arr['version'] ?? '1.0';
 }

--- a/plugin/src/meta.php
+++ b/plugin/src/meta.php
@@ -29,7 +29,7 @@ function register_meta_helper(
 	array $object_slugs,
 	string $meta_key,
 	array $args = []
-) : bool {
+): bool {
 
 	// Object type must be either post or term.
 	if ( ! in_array( $object_type, [ 'post', 'term' ], true ) ) {


### PR DESCRIPTION
Add `@starting-style` to list of allowed at rules because it is well-supported and should be allowed in our SCSS files.

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@starting-style

Also, update `alleyinteractive/alley-coding-standards` and fix resulting errors.